### PR TITLE
Reduce async sleep values to zero

### DIFF
--- a/onboard/python/implementation/cloudlets/PartialOffloadCloudlet.py
+++ b/onboard/python/implementation/cloudlets/PartialOffloadCloudlet.py
@@ -70,7 +70,7 @@ class PartialOffloadCloudlet(CloudletItf.CloudletItf):
 
     def sendFrame(self):
         async def producer():
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             input_frame = gabriel_pb2.InputFrame()
             if not self.stop:
                 try:
@@ -90,15 +90,15 @@ class PartialOffloadCloudlet(CloudletItf.CloudletItf):
                 input_frame.payloads.append("Streaming not started, no frame to show.")
 
             return input_frame
-                    
+
         return ProducerWrapper(producer=producer, source_name=self.source)
 
     def getResults(self, engine_key):
-        try:    
+        try:
             return self.engine_results.pop(engine_key)
         except:
             return None
-        
+
     def clearResults(self, engine_key):
         self.engine_results[engine_key] = None
-   
+

--- a/onboard/python/implementation/cloudlets/PureOffloadCloudlet.py
+++ b/onboard/python/implementation/cloudlets/PureOffloadCloudlet.py
@@ -84,7 +84,7 @@ class PureOffloadCloudlet(CloudletItf.CloudletItf):
 
     def sendFrame(self):
         async def producer():
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0)
             input_frame = gabriel_pb2.InputFrame()
             if not self.stop:
                 try:
@@ -105,14 +105,14 @@ class PureOffloadCloudlet(CloudletItf.CloudletItf):
                 input_frame.payloads.append("Streaming not started, no frame to show.")
 
             return input_frame
-                    
+
         return ProducerWrapper(producer=producer, source_name=self.source)
 
     def getResults(self, engine_key):
-        try:    
+        try:
             return self.engine_results.pop(engine_key)
         except:
             return None
-        
+
     def clearResults(self, engine_key):
         self.engine_results[engine_key] = None

--- a/onboard/python/supervisor.py
+++ b/onboard/python/supervisor.py
@@ -163,7 +163,7 @@ class Supervisor:
         req = cnc_pb2.Extras()
         req.drone_id = name
         while True:
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0)
             try:
                 self.zmq.send(req.SerializeToString())
                 rep = self.zmq.recv()
@@ -233,7 +233,7 @@ class Supervisor:
 
     def get_producer_wrappers(self):
         async def producer():
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             self.heartbeats += 1
             input_frame = gabriel_pb2.InputFrame()
             input_frame.payload_type = gabriel_pb2.PayloadType.TEXT


### PR DESCRIPTION
We current have values of 0.1 or 0.01 for async sleep. This amounts to 10ms or 100ms. This is a lot more than is needed to prevent starvation of other async tasks.

asyncio documentation states:

  Setting the delay to 0 provides an optimized path to allow other
  tasks to run. This can be used by long-running functions to avoid
  blocking the event loop for the full duration of the function call.

Set these values to 0 instead.