### PR TITLE
Various fixes for issues flagged by the 'ruff check' linter.

### DIFF
--- a/.github/workflows/build-swarm-controller.yml
+++ b/.github/workflows/build-swarm-controller.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-swarm-controller.yml'
+      - '.github/workflows/deploy-docker-img.yml'
       - 'backend/server/engines/swarm_controller/**'
       - 'protocols/**'
       - 'vehicle/util/**'

--- a/.github/workflows/build-swarm-controller.yml
+++ b/.github/workflows/build-swarm-controller.yml
@@ -2,7 +2,7 @@ name: Build and push swarm controller
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-swarm-controller.yml'
       - 'backend/server/engines/swarm_controller/**'
@@ -11,37 +11,8 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
-
-    - name: Download protobuf compiler
-      run: wget https://github.com/protocolbuffers/protobuf/releases/download/v29.4/protoc-29.4-linux-x86_64.zip
-
-    - name: Unzip protobuf compiler
-      run: unzip -d protobuf protoc-29.4-linux-x86_64.zip
-
-    - name: Build protobufs
-      run: cd protocol && PROTOC_PATH=../protobuf/bin/protoc ./build.sh
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build and push vehicle image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: backend/server/engines/swarm_controller/Dockerfile
-        push: true
-        tags: cmusatyalab/steeleagle-swarm-controller:dev
-        cache-from: type=registry,ref=cmusatyalab/steeleagle-swarm-controller:dev
-        cache-to: type=inline
+    uses: ./.github/workflows/deploy-docker-img.yml
+    with:
+      name: steeleagle-swarm-controller
+      dockerfile: backend/server/engines/swarm_controller/Dockerfile
+    secrets: inherit

--- a/.github/workflows/build-telemetry-engine.yml
+++ b/.github/workflows/build-telemetry-engine.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-telemetry-engine.yml'
+      - '.github/workflows/deploy-docker-img.yml'
       - 'backend/server/engines/telemetry/**'
       - 'protocol/**'
       - 'vehicle/util/**'

--- a/.github/workflows/build-telemetry-engine.yml
+++ b/.github/workflows/build-telemetry-engine.yml
@@ -2,7 +2,7 @@ name: Build and push telemetry engine
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-telemetry-engine.yml'
       - 'backend/server/engines/telemetry/**'
@@ -11,37 +11,8 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
-
-    - name: Download protobuf compiler
-      run: wget https://github.com/protocolbuffers/protobuf/releases/download/v29.4/protoc-29.4-linux-x86_64.zip
-
-    - name: Unzip protobuf compiler
-      run: unzip -d protobuf protoc-29.4-linux-x86_64.zip
-
-    - name: Build protobufs
-      run: cd protocol && PROTOC_PATH=../protobuf/bin/protoc ./build.sh
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build and push vehicle image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: backend/server/engines/telemetry/Dockerfile.telemetry
-        push: true
-        tags: cmusatyalab/steeleagle-telemetry-engine:dev
-        cache-from: type=registry,ref=cmusatyalab/steeleagle-telemetry-engine:dev
-        cache-to: type=inline
+    uses: ./.github/workflows/deploy-docker-img.yml
+    with:
+      name: steeleagle-telemetry-engine
+      dockerfile: backend/server/engines/telemetry/Dockerfile.telemetry
+    secrets: inherit

--- a/.github/workflows/build-vehicle.yml
+++ b/.github/workflows/build-vehicle.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/build-vehicle.yml'
       - '.github/workflows/deploy-docker-img.yml'
       - 'backend/server/steeleagle-dsl/python/interface/**'
+      - 'backend/server/steeleagle-dsl'
       - 'protocol/**'
       - 'vehicle/**'
 

--- a/.github/workflows/build-vehicle.yml
+++ b/.github/workflows/build-vehicle.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-vehicle.yml'
+      - '.github/workflows/deploy-docker-img.yml'
       - 'backend/server/steeleagle-dsl/python/interface/**'
       - 'protocol/**'
       - 'vehicle/**'

--- a/.github/workflows/build-vehicle.yml
+++ b/.github/workflows/build-vehicle.yml
@@ -2,7 +2,7 @@ name: Build and push vehicle container
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-vehicle.yml'
       - 'backend/server/steeleagle-dsl/python/interface/**'
@@ -11,37 +11,8 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
-
-    - name: Download protobuf compiler
-      run: wget https://github.com/protocolbuffers/protobuf/releases/download/v29.4/protoc-29.4-linux-x86_64.zip
-
-    - name: Unzip protobuf compiler
-      run: unzip -d protobuf protoc-29.4-linux-x86_64.zip
-
-    - name: Build protobufs
-      run: cd protocol && PROTOC_PATH=../protobuf/bin/protoc ./build.sh
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build and push vehicle image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: vehicle/Dockerfile
-        push: true
-        tags: cmusatyalab/steeleagle-vehicle:dev
-        cache-from: type=registry,ref=cmusatyalab/steeleagle-vehicle:dev
-        cache-to: type=inline
+    uses: ./.github/workflows/deploy-docker-img.yml
+    with:
+      name: steeleagle-vehicle
+      dockerfile: vehicle/Dockerfile
+    secrets: inherit

--- a/.github/workflows/build-vision-engines.yml
+++ b/.github/workflows/build-vision-engines.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-vision-engines.yml'
+      - '.github/workflows/deploy-docker-img.yml'
       - 'backend/server/engines/avoidance/**'
       - 'backend/server/engines/detection/**'
       - 'backend/server/engines/Dockerfile.obj_avoid'

--- a/.github/workflows/build-vision-engines.yml
+++ b/.github/workflows/build-vision-engines.yml
@@ -2,7 +2,7 @@ name: Build and push vision engines
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - '.github/workflows/build-vision-engines.yml'
       - 'backend/server/engines/avoidance/**'
@@ -15,48 +15,9 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@v1.3.1
-      with:
-        tool-cache: false
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: false
-        docker-images: false
-        swap-storage: false
-
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'true'
-
-    - name: Download protobuf compiler
-      run: wget https://github.com/protocolbuffers/protobuf/releases/download/v29.4/protoc-29.4-linux-x86_64.zip
-
-    - name: Unzip protobuf compiler
-      run: unzip -d protobuf protoc-29.4-linux-x86_64.zip
-
-    - name: Build protobufs
-      run: cd protocol && PROTOC_PATH=../protobuf/bin/protoc ./build.sh
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build and push vision engine image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: backend/server/engines/Dockerfile.obj_avoid
-        push: true
-        tags: cmusatyalab/steeleagle-vision-engines:dev
-        cache-from: type=registry,ref=cmusatyalab/steeleagle-vision-engines:dev
-        cache-to: type=inline
+    uses: ./.github/workflows/deploy-docker-img.yml
+    with:
+      name: steeleagle-vision-engines
+      dockerfile: backend/server/engines/Dockerfile.obj_avoid
+      free_disk_space: true
+    secrets: inherit

--- a/.github/workflows/deploy-docker-img.yml
+++ b/.github/workflows/deploy-docker-img.yml
@@ -60,9 +60,9 @@ jobs:
     - name: Set Docker image tag
       id: get_tag
       run: |
-        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+        if [ "${{ github.ref_name }}" == "main" ]; then
           echo "tag=latest" >> "$GITHUB_OUTPUT"
-        elif [ "${{ github.ref }}" == "refs/heads/dev" ]; then
+        elif [ "${{ github.ref_name }}" == "dev" ]; then
           echo "tag=dev" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/deploy-docker-img.yml
+++ b/.github/workflows/deploy-docker-img.yml
@@ -73,5 +73,5 @@ jobs:
         file: ${{ inputs.dockerfile }}
         push: true
         tags: cmusatyalab/${{ inputs.name }}:${{ steps.get_tag.outputs.tag }}
-        cache-from: type=registry,ref=cmusatyalab/steeleagle-swarm-controller:${{ steps.get_tag.outputs.tag }}
+        cache-from: type=registry,ref=cmusatyalab/${{ inputs.name }}:dev
         cache-to: type=inline

--- a/.github/workflows/deploy-docker-img.yml
+++ b/.github/workflows/deploy-docker-img.yml
@@ -1,0 +1,77 @@
+name: Deploy SteelEagle Docker image
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      free_disk_space:
+        description: 'Whether to free disk space in the runner'
+        type: boolean
+        default: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: false
+      if: ${{ inputs.free_disk_space }}
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+
+    - name: Download protobuf compiler
+      run: wget https://github.com/protocolbuffers/protobuf/releases/download/v29.4/protoc-29.4-linux-x86_64.zip
+
+    - name: Unzip protobuf compiler
+      run: unzip -d protobuf protoc-29.4-linux-x86_64.zip
+
+    - name: Build protobufs
+      run: cd protocol && PROTOC_PATH=../protobuf/bin/protoc ./build.sh
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Set Docker image tag
+      id: get_tag
+      run: |
+        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+          echo "tag=latest" >> "$GITHUB_OUTPUT"
+        elif [ "${{ github.ref }}" == "refs/heads/dev" ]; then
+          echo "tag=dev" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build and push image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        push: true
+        tags: cmusatyalab/${{ inputs.name }}:${{ steps.get_tag.outputs.tag }}
+        cache-from: type=registry,ref=cmusatyalab/steeleagle-swarm-controller:${{ steps.get_tag.outputs.tag }}
+        cache-to: type=inline

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -9,3 +9,8 @@ select = [
   "F",      # pyflakes
   "I"       # isort
 ]
+ignore = [
+  "E722",   # do not use bare except
+  "E741",   # ambiguous variable name (seems to trigger on l, I, and such)
+  "F841",   # unused local variable
+]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 target-version = "py310"
-exclude = ["*_pb2.py"]
+exclude = ["*_pb2.py", "*_pb2.pyi"]
 
 [lint]
 select = [
@@ -7,7 +7,8 @@ select = [
   "E7",     # pycodestyle subset
   "E9",     # pycodestyle subset
   "F",      # pyflakes
-  "I"       # isort
+  "I",      # isort
+  "UP",     # pyupgrade
 ]
 ignore = [
   "E722",   # do not use bare except

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,2 @@
+target-version = "py310"
+exclude = ["*_pb2.py"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,2 +1,11 @@
 target-version = "py310"
 exclude = ["*_pb2.py"]
+
+[lint]
+select = [
+  "E4",     # pycodestyle subset
+  "E7",     # pycodestyle subset
+  "E9",     # pycodestyle subset
+  "F",      # pyflakes
+  "I"       # isort
+]

--- a/backend/server/docker-compose.yml
+++ b/backend/server/docker-compose.yml
@@ -7,7 +7,6 @@
 # ${FACE_THRESHOLD} and ${API_KEY} should
 # reside in a .env file along side docker-compose.yaml
 
-version: '2.3'
 services:
   gabriel-server:
     image: cmusatyalab/gabriel-server

--- a/backend/server/docker-compose.yml
+++ b/backend/server/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - cnc-net
 
   telemetry-engine:
-    image: cmusatyalab/steeleagle-telemetry-engine
+    image: cmusatyalab/steeleagle-telemetry-engine:${TAG}
     container_name: telemetry-engine
     restart: unless-stopped
     privileged: true
@@ -37,7 +37,7 @@ services:
       - PYTHONPATH=/protocol
 
   swarm-controller:
-    image: cmusatyalab/steeleagle-swarm-controller
+    image: cmusatyalab/steeleagle-swarm-controller:${TAG}
     container_name: swarm-controller
     restart: unless-stopped
     ports:
@@ -116,7 +116,7 @@ services:
         #    - WEBSERVER=${WEBSERVER_URL}:${HTTP_PORT}
 
   obstacle-engine:
-    image: cmusatyalab/steeleagle-vision-engines
+    image: cmusatyalab/steeleagle-vision-engines:${TAG}
     container_name: obstacle-engine
     restart: unless-stopped
     privileged: true
@@ -145,7 +145,7 @@ services:
     #  - CUDA_VISIBLE_DEVICES=1 #set this if you want to force CPU only
 
   object-engine:
-    image: cmusatyalab/steeleagle-vision-engines
+    image: cmusatyalab/steeleagle-vision-engines:${TAG}
     container_name: object-engine
     restart: unless-stopped
     privileged: true

--- a/backend/server/engines/avoidance/depth.py
+++ b/backend/server/engines/avoidance/depth.py
@@ -18,10 +18,11 @@
 #   limitations under the License.
 #
 #
-from gabriel_server.network_engine import engine_runner
-from obstacle_avoidance_engine import MidasAvoidanceEngine, Metric3DAvoidanceEngine
-import logging
 import argparse
+import logging
+
+from gabriel_server.network_engine import engine_runner
+from obstacle_avoidance_engine import Metric3DAvoidanceEngine, MidasAvoidanceEngine
 from util.utils import setup_logging
 
 SOURCE = 'openscout'

--- a/backend/server/engines/avoidance/depth.py
+++ b/backend/server/engines/avoidance/depth.py
@@ -25,9 +25,10 @@ from gabriel_server.network_engine import engine_runner
 from obstacle_avoidance_engine import Metric3DAvoidanceEngine, MidasAvoidanceEngine
 from util.utils import setup_logging
 
-SOURCE = 'openscout'
+SOURCE = "openscout"
 
 logger = logging.getLogger(__name__)
+
 
 def main():
     setup_logging(logger)
@@ -35,48 +36,69 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
+    parser.add_argument("-p", "--port", type=int, default=9099, help="Set port number")
+
     parser.add_argument(
-        "-p", "--port", type=int, default=9099, help="Set port number"
+        "-m",
+        "--model",
+        default="DPT_Large",
+        help="MiDaS model. Valid models are ['DPT_Large', 'DPT_Hybrid', 'MiDaS_small']",
     )
 
     parser.add_argument(
-        "-m", "--model", default="DPT_Large", help="MiDaS model. Valid models are ['DPT_Large', 'DPT_Hybrid', 'MiDaS_small']"
+        "-r",
+        "--threshold",
+        type=int,
+        default=190,
+        help="Depth threshold for filtering.",
     )
 
     parser.add_argument(
-        "-r", "--threshold", type=int, default=190, help="Depth threshold for filtering."
+        "-s",
+        "--store",
+        action="store_true",
+        default=False,
+        help="Store images with heatmap",
     )
 
     parser.add_argument(
-        "-s", "--store", action="store_true", default=False, help="Store images with heatmap"
+        "-g",
+        "--gabriel",
+        default="tcp://gabriel-server:5555",
+        help="Gabriel server endpoint.",
     )
 
     parser.add_argument(
-        "-g", "--gabriel",  default="tcp://gabriel-server:5555", help="Gabriel server endpoint."
+        "-src", "--source", default=SOURCE, help="Source for engine to register with."
     )
 
     parser.add_argument(
-        "-src", "--source",  default=SOURCE, help="Source for engine to register with."
+        "-f",
+        "--faux",
+        action="store_true",
+        default=False,
+        help="Generate faux vectors using the file specfied instead of results from MiDaS.",
     )
 
     parser.add_argument(
-        "-f", "--faux",  action="store_true", default=False, help="Generate faux vectors using the file specfied instead of results from MiDaS."
+        "-R",
+        "--redis",
+        type=int,
+        default=6379,
+        help="Set port number for redis connection [default: 6379]",
     )
 
-    parser.add_argument(
-        "-R", "--redis", type=int, default=6379, help="Set port number for redis connection [default: 6379]"
-    )
-
-    parser.add_argument(
-        "-a", "--auth", default="", help="Share key for redis user."
-    )
+    parser.add_argument("-a", "--auth", default="", help="Share key for redis user.")
 
     parser.add_argument(
         "-i", "--roi", type=int, default=190, help="Depth threshold for filtering."
     )
 
     parser.add_argument(
-        "--metric3d", action="store_true", default=False, help="Use Metric3D for avoidance"
+        "--metric3d",
+        action="store_true",
+        default=False,
+        help="Use Metric3D for avoidance",
     )
 
     args, _ = parser.parse_known_args()
@@ -88,7 +110,13 @@ def main():
             engine = MidasAvoidanceEngine(args)
         return engine
 
-    engine_runner.run(engine=engine_setup(), source_name=args.source, server_address=args.gabriel, all_responses_required=True)
+    engine_runner.run(
+        engine=engine_setup(),
+        source_name=args.source,
+        server_address=args.gabriel,
+        all_responses_required=True,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/backend/server/engines/avoidance/obstacle_avoidance_engine.py
+++ b/backend/server/engines/avoidance/obstacle_avoidance_engine.py
@@ -247,7 +247,7 @@ class MidasAvoidanceEngine(cognitive_engine.Engine, AvoidanceEngine):
 
         if self.model == "MiDaS_small":
             self.transform = midas_transforms.small_transform
-        elif self.model == "DPT_SwinV2_L_384" or "DPT_SwinV2_B_384" or "DPT_Swin_L_384":
+        elif self.model in ["DPT_SwinV2_L_384", "DPT_SwinV2_B_384", "DPT_Swin_L_384"]:
             self.transform = midas_transforms.swin384_transform
         elif self.model == "MiDaS":
             self.transform = midas_transforms.default_transform

--- a/backend/server/engines/avoidance/obstacle_avoidance_engine.py
+++ b/backend/server/engines/avoidance/obstacle_avoidance_engine.py
@@ -72,7 +72,7 @@ class AvoidanceEngine(ABC):
                     self.storage_path + "/actuations.txt"
                 )
             )
-            self.actuations_fd = open(self.storage_path + "/actuations.txt", mode="r")
+            self.actuations_fd = open(self.storage_path + "/actuations.txt")
 
         if self.store_detections:
             self.watermark = Image.open(os.getcwd() + "/watermark.png")
@@ -81,7 +81,7 @@ class AvoidanceEngine(ABC):
                 os.makedirs(self.storage_path + "/moa")
             except FileExistsError:
                 logger.info("Images directory already exists.")
-            logger.info("Storing detection images at {}".format(self.storage_path))
+            logger.info(f"Storing detection images at {self.storage_path}")
 
     def store_vector(self, drone, vec):
         self.r.xadd(
@@ -90,13 +90,11 @@ class AvoidanceEngine(ABC):
         )
 
     def print_inference_stats(self):
-        logger.info("inference time {0:.1f} ms, ".format((self.t1 - self.t0) * 1000))
-        logger.info("wait {0:.1f} ms, ".format((self.t0 - self.lasttime) * 1000))
-        logger.info("fps {0:.2f}".format(1.0 / (self.t1 - self.lasttime)))
+        logger.info(f"inference time {(self.t1 - self.t0) * 1000:.1f} ms, ")
+        logger.info(f"wait {(self.t0 - self.lasttime) * 1000:.1f} ms, ")
+        logger.info(f"fps {1.0 / (self.t1 - self.lasttime):.2f}")
         logger.info(
-            "avg fps: {0:.2f}".format(
-                (self.count - self.lastcount) / (self.t1 - self.lastprint)
-            )
+            f"avg fps: {(self.count - self.lastcount) / (self.t1 - self.lastprint):.2f}"
         )
         self.lastcount = self.count
         self.lastprint = self.t1
@@ -133,7 +131,7 @@ class AvoidanceEngine(ABC):
         path = self.storage_path + "/moa/latest.jpg"
         depth_img.save(path, format="JPEG")
 
-        logger.info("Stored image: {}".format(path))
+        logger.info(f"Stored image: {path}")
 
     def text_payload_reply(self):
         # if the payload is TEXT, say from a CNC client, we ignore
@@ -142,7 +140,7 @@ class AvoidanceEngine(ABC):
 
         result = gabriel_pb2.ResultWrapper.Result()
         result.payload_type = gabriel_pb2.PayloadType.TEXT
-        result.payload = "Ignoring TEXT payload.".encode(encoding="utf-8")
+        result.payload = b"Ignoring TEXT payload."
         result_wrapper.results.append(result)
         return result_wrapper
 
@@ -180,9 +178,7 @@ class AvoidanceEngine(ABC):
             result_wrapper = self.get_result_wrapper(status)
             result = gabriel_pb2.ResultWrapper.Result()
             result.payload_type = gabriel_pb2.PayloadType.TEXT
-            result.payload = "Expected compute configuration to be specified".encode(
-                encoding="utf-8"
-            )
+            result.payload = b"Expected compute configuration to be specified"
             result_wrapper.results.append(result)
             return result_wrapper
 
@@ -263,10 +259,8 @@ class MidasAvoidanceEngine(cognitive_engine.Engine, AvoidanceEngine):
             self.transform = midas_transforms.beit512_transform
         else:
             self.transform = midas_transforms.dpt_transform
-        logger.info(
-            "Depth predictor initialized with the following model: {}".format(model)
-        )
-        logger.info("Depth Threshold: {}".format(self.threshold))
+        logger.info(f"Depth predictor initialized with the following model: {model}")
+        logger.info(f"Depth Threshold: {self.threshold}")
 
     def handle(self, input_frame):
         return self.handle_helper(input_frame)
@@ -330,7 +324,7 @@ class MidasAvoidanceEngine(cognitive_engine.Engine, AvoidanceEngine):
         )
         cv2.putText(
             full_depth_map,
-            "{:.4f}".format(actuation_vector),
+            f"{actuation_vector:.4f}",
             (scrapX + cX, scrapY + cY - 10),
             cv2.FONT_HERSHEY_SIMPLEX,
             0.5,
@@ -375,10 +369,8 @@ class Metric3DAvoidanceEngine(cognitive_engine.Engine, AvoidanceEngine):
         self.detector.to(self.device)
         self.detector.eval()
 
-        logger.info(
-            "Depth predictor initialized with the following model: {}".format(model)
-        )
-        logger.info("Depth Threshold: {}".format(self.threshold))
+        logger.info(f"Depth predictor initialized with the following model: {model}")
+        logger.info(f"Depth Threshold: {self.threshold}")
 
     def handle(self, input_frame):
         return self.handle_helper(input_frame)

--- a/backend/server/engines/avoidance/obstacle_avoidance_engine.py
+++ b/backend/server/engines/avoidance/obstacle_avoidance_engine.py
@@ -18,21 +18,23 @@
 #
 #
 
-from abc import ABC, abstractmethod
-import time
+import json
+import logging
 import os
+import time
+from abc import ABC, abstractmethod
+
 import cv2
 import numpy as np
-import logging
-from gabriel_server import cognitive_engine
+import redis
+import torch
 from gabriel_protocol import gabriel_pb2
+from gabriel_server import cognitive_engine
+from PIL import Image, ImageDraw
+
 import protocol.common_pb2 as common
 import protocol.controlplane_pb2 as control_plane
 import protocol.gabriel_extras_pb2 as gabriel_extras
-from PIL import Image, ImageDraw
-import json
-import torch
-import redis
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/backend/server/engines/detection/obj.py
+++ b/backend/server/engines/detection/obj.py
@@ -20,16 +20,17 @@
 #
 import argparse
 
-#from timing_engine import TimingObjectEngine
+# from timing_engine import TimingObjectEngine
 import logging
 
 from gabriel_server.network_engine import engine_runner
 from openscout_object_engine import OpenScoutObjectEngine
 from util.utils import setup_logging
 
-SOURCE = 'openscout'
+SOURCE = "openscout"
 
 logger = logging.getLogger(__name__)
+
 
 def main():
     setup_logging(logger)
@@ -41,68 +42,93 @@ def main():
         "--timing", action="store_true", help="Print timing information"
     )
 
+    parser.add_argument("-p", "--port", type=int, default=9099, help="Set port number")
+
     parser.add_argument(
-        "-p", "--port", type=int, default=9099, help="Set port number"
+        "-m",
+        "--model",
+        default="coco",
+        help="(OBJECT DETECTION) Subdirectory under /openscout/server/model/ which contains Tensorflow model to load initially.",
     )
 
     parser.add_argument(
-        "-m", "--model", default="coco",
-        help="(OBJECT DETECTION) Subdirectory under /openscout/server/model/ which contains Tensorflow model to load initially."
+        "-r", "--threshold", type=float, default=0.85, help="Confidence threshold"
     )
 
     parser.add_argument(
-        "-r", "--threshold", type=float, default=0.85,
-        help="Confidence threshold"
+        "-s",
+        "--store",
+        action="store_true",
+        default=False,
+        help="Store images with bounding boxes",
     )
 
     parser.add_argument(
-        "-s", "--store", action="store_true", default=False, help="Store images with bounding boxes"
+        "-g",
+        "--gabriel",
+        default="tcp://gabriel-server:5555",
+        help="Gabriel server endpoint.",
     )
 
     parser.add_argument(
-        "-g", "--gabriel",  default="tcp://gabriel-server:5555", help="Gabriel server endpoint."
+        "-src", "--source", default=SOURCE, help="Source for engine to register with."
     )
 
     parser.add_argument(
-        "-src", "--source",  default=SOURCE, help="Source for engine to register with."
+        "-x",
+        "--exclude",
+        help="Comma separated list of classes (ids) to exclude when peforming detection. Consult model/<model_name>/label_map.pbtxt.",
     )
 
     parser.add_argument(
-        "-x", "--exclude",
-        help="Comma separated list of classes (ids) to exclude when peforming detection. Consult model/<model_name>/label_map.pbtxt."
+        "-d",
+        "--drone",
+        default="anafi",
+        help="Drone model ([anafi,usa]).  Used to define HFOV and VFOV for camera.",
+    )
+    parser.add_argument(
+        "-R",
+        "--redis",
+        type=int,
+        default=6379,
+        help="Set port number for redis connection [default: 6379]",
+    )
+
+    parser.add_argument("-a", "--auth", default="", help="Share key for redis user.")
+
+    parser.add_argument(
+        "-hsv",
+        "--hsv_threshold",
+        type=float,
+        default=5.0,
+        help="HSV filter threshold [0.0-100.0]",
     )
 
     parser.add_argument(
-        "-d", "--drone", default='anafi',
-        help="Drone model ([anafi,usa]).  Used to define HFOV and VFOV for camera."
-    )
-    parser.add_argument(
-        "-R", "--redis", type=int, default=6379,
-        help="Set port number for redis connection [default: 6379]"
+        "--radius",
+        type=float,
+        default=5.0,
+        help="Radius in meters to consider when looking for previously found objects.",
     )
 
     parser.add_argument(
-        "-a", "--auth", default="", help="Share key for redis user."
+        "--ttl",
+        type=int,
+        default=1200,
+        help="TTL in seconds before objects are cleaned up in redis [default: 1200]",
     )
 
     parser.add_argument(
-        "-hsv", "--hsv_threshold", type=float, default=5.0, help="HSV filter threshold [0.0-100.0]"
+        "--geofence",
+        default="geofence.kml",
+        help="Path to KML file on the shared volume that specified the geofence. [default: geofence.kml]",
     )
 
     parser.add_argument(
-        "--radius", type=float, default=5.0, help="Radius in meters to consider when looking for previously found objects."
-    )
-
-    parser.add_argument(
-        "--ttl", type=int, default=1200, help="TTL in seconds before objects are cleaned up in redis [default: 1200]"
-    )
-
-    parser.add_argument(
-        "--geofence",  default="geofence.kml", help="Path to KML file on the shared volume that specified the geofence. [default: geofence.kml]"
-    )
-
-    parser.add_argument(
-        "--geofence_enabled", action="store_true", default=False, help="Whether to use a geofence to decide whether to store detections"
+        "--geofence_enabled",
+        action="store_true",
+        default=False,
+        help="Whether to use a geofence to decide whether to store detections",
     )
 
     args, _ = parser.parse_known_args()
@@ -116,7 +142,13 @@ def main():
         return engine
 
     logger.info("Starting object detection cognitive engine..")
-    engine_runner.run(engine=object_engine_setup(), source_name=args.source, server_address=args.gabriel, all_responses_required=True)
+    engine_runner.run(
+        engine=object_engine_setup(),
+        source_name=args.source,
+        server_address=args.gabriel,
+        all_responses_required=True,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/backend/server/engines/detection/obj.py
+++ b/backend/server/engines/detection/obj.py
@@ -18,11 +18,13 @@
 #   limitations under the License.
 #
 #
-from gabriel_server.network_engine import engine_runner
-from openscout_object_engine import OpenScoutObjectEngine
+import argparse
+
 #from timing_engine import TimingObjectEngine
 import logging
-import argparse
+
+from gabriel_server.network_engine import engine_runner
+from openscout_object_engine import OpenScoutObjectEngine
 from util.utils import setup_logging
 
 SOURCE = 'openscout'

--- a/backend/server/engines/detection/obj.py
+++ b/backend/server/engines/detection/obj.py
@@ -135,7 +135,8 @@ def main():
 
     def object_engine_setup():
         if args.timing:
-            engine = TimingObjectEngine(args)
+            # engine = TimingObjectEngine(args)
+            raise NotImplementedError
         else:
             engine = OpenScoutObjectEngine(args)
 

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -95,7 +95,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             logger.error(f"Geofence KML file not found or is not a file: {fence_path}")
         else:
             # build geofence from coordinates inside Polygon element of KML file
-            with open(f"{fence_path}", "r", encoding="utf-8") as f:
+            with open(f"{fence_path}", encoding="utf-8") as f:
                 root = parser.parse(f).getroot()
                 coords = root.Document.Placemark.Polygon.outerBoundaryIs.LinearRing.coordinates.text
                 for c in coords.split():
@@ -109,14 +109,14 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             self.exclusions = list(
                 map(int, args.exclude.split(","))
             )  # split string to int list
-            logger.info("Excluding the following class ids: {}".format(self.exclusions))
+            logger.info(f"Excluding the following class ids: {self.exclusions}")
         else:
             self.exclusions = None
 
         logger.info(
-            "Predictor initialized with the following model path: {}".format(args.model)
+            f"Predictor initialized with the following model path: {args.model}"
         )
-        logger.info("Confidence Threshold: {}".format(self.threshold))
+        logger.info(f"Confidence Threshold: {self.threshold}")
 
         if self.store_detections:
             self.watermark = Image.open(os.getcwd() + "/watermark.png")
@@ -125,7 +125,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                 os.makedirs(self.storage_path + "/detected")
             except FileExistsError:
                 logger.info("Images directory already exists.")
-            logger.info("Storing detection images at {}".format(self.storage_path))
+            logger.info(f"Storing detection images at {self.storage_path}")
 
             self.drone_storage_path = os.path.join(
                 self.storage_path, "detected", "drones"
@@ -160,9 +160,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         img_height = image_np.shape[0]
         pixel_center = (img_width / 2, img_height / 2)
         logger.info(
-            "Image Width: {0}px, Image Height: {1}px, Center {2}".format(
-                img_width, img_height, pixel_center
-            )
+            f"Image Width: {img_width}px, Image Height: {img_height}px, Center {pixel_center}"
         )
         # eventually these should come from something like a drone .cap file
         HFOV = 69  # Horizontal FOV An.
@@ -194,14 +192,12 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         target_vec = self.find_intersection(target_dir, np.array([0, 0, alt]))
 
         logger.info(
-            "Intersection with ground plane: ({0}, {1}, {2})".format(
-                target_vec[0], target_vec[1], target_vec[2]
-            )
+            f"Intersection with ground plane: ({target_vec[0]}, {target_vec[1]}, {target_vec[2]})"
         )
 
         est_lat = lat + (180 / np.pi) * (target_vec[1] / EARTH_RADIUS)
         est_lon = lon + (180 / np.pi) * (target_vec[0] / EARTH_RADIUS) / np.cos(lat)
-        logger.info("Estimated GPS location: ({0}, {1})".format(est_lat, est_lon))
+        logger.info(f"Estimated GPS location: ({est_lat}, {est_lon})")
         return est_lat, est_lon
 
     def geodb_garbage_collection(self):
@@ -272,7 +268,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             result_wrapper.result_producer_name.value = self.ENGINE_NAME
             result = gabriel_pb2.ResultWrapper.Result()
             result.payload_type = gabriel_pb2.PayloadType.TEXT
-            result.payload = "Ignoring TEXT payload.".encode(encoding="utf-8")
+            result.payload = b"Ignoring TEXT payload."
             result_wrapper.results.append(result)
             return result_wrapper
 
@@ -285,9 +281,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             result_wrapper.result_producer_name.value = self.ENGINE_NAME
             result = gabriel_pb2.ResultWrapper.Result()
             result.payload_type = gabriel_pb2.PayloadType.TEXT
-            result.payload = "Expected compute configuration to be specified".encode(
-                encoding="utf-8"
-            )
+            result.payload = b"Expected compute configuration to be specified"
             result_wrapper.results.append(result)
             return result_wrapper
 
@@ -363,7 +357,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
 
             if scores[i] > self.threshold:
                 detections_above_threshold = True
-                logger.info("Detected : {} - Score: {:.3f}".format(names[i], scores[i]))
+                logger.info(f"Detected : {names[i]} - Score: {scores[i]:.3f}")
 
                 box = df["box"][i]
                 box = [box["y1"], box["x1"], box["y2"], box["x2"]]
@@ -559,13 +553,11 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         return (True, None)
 
     def print_inference_stats(self):
-        logger.info("inference time {0:.1f} ms, ".format((self.t1 - self.t0) * 1000))
-        logger.info("wait {0:.1f} ms, ".format((self.t0 - self.lasttime) * 1000))
-        logger.info("fps {0:.2f}".format(1.0 / (self.t1 - self.lasttime)))
+        logger.info(f"inference time {(self.t1 - self.t0) * 1000:.1f} ms, ")
+        logger.info(f"wait {(self.t0 - self.lasttime) * 1000:.1f} ms, ")
+        logger.info(f"fps {1.0 / (self.t1 - self.lasttime):.2f}")
         logger.info(
-            "avg fps: {0:.2f}".format(
-                (self.count - self.lastcount) / (self.t1 - self.lastprint)
-            )
+            f"avg fps: {(self.count - self.lastcount) / (self.t1 - self.lastprint):.2f}"
         )
         self.lastcount = self.count
         self.lastprint = self.t1

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -18,24 +18,26 @@
 #
 #
 
-import time
+import json
+import logging
 import os
+import time
+import traceback
+
 import cv2
 import numpy as np
-import logging
-from gabriel_server import cognitive_engine
+import redis
 from gabriel_protocol import gabriel_pb2
+from gabriel_server import cognitive_engine
+from PIL import Image
+from pygeodesy.sphericalNvector import LatLon
+from pykml import parser
+from scipy.spatial.transform import Rotation as R
+from ultralytics import YOLO
+
 import protocol.common_pb2 as common
 import protocol.controlplane_pb2 as control_plane
 import protocol.gabriel_extras_pb2 as gabriel_extras
-from PIL import Image
-import traceback
-import json
-from scipy.spatial.transform import Rotation as R
-import redis
-from ultralytics import YOLO
-from pygeodesy.sphericalNvector import LatLon
-from pykml import parser
 
 logger = logging.getLogger(__name__)
 

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -309,7 +309,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                     position.longitude,
                     target_pitch,
                     target_yaw,
-                    position.relative_altitude)
+                    telemetry.relative_position.up)
 
                 lon = np.clip(lon, -180, 180)
                 lat = np.clip(lat, -85, 85)

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -396,7 +396,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             path = os.path.join(class_dir, filename)
             logger.debug(f"Stored image: {path}")
 
-            os.symlink(drone_dir_path, path)
+            os.symlink(os.path.join("..", "..", "drones", drone_id, filename), path)
 
     def store_hsv_image(self, image_np, cpt_config, drone_id):
         img = self.run_hsv_filter(image_np, cpt_config)

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -360,7 +360,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             return gabriel_result if detections_above_threshold else None
 
         if run_hsv_filter:
-            self.store_hsv_image(image_np, cpt_config)
+            self.store_hsv_image(image_np, cpt_config, drone_id)
 
         # Store detection image
         if detections_above_threshold:
@@ -398,9 +398,10 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
 
             os.symlink(drone_dir_path, path)
 
-    def store_hsv_image(self, image_np, cpt_config):
+    def store_hsv_image(self, image_np, cpt_config, drone_id):
         img = self.run_hsv_filter(image_np, cpt_config)
-        path = self.storage_path + "/detected/hsv.jpg"
+
+        path = os.path.join(self.drone_storage_path, drone_id)
         img.save(path, format="JPEG")
 
     def run_hsv_filter(self, image_np, cpt_config):

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -416,7 +416,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
     def store_hsv_image(self, image_np, cpt_config, drone_id):
         img = self.run_hsv_filter(image_np, cpt_config)
 
-        path = os.path.join(self.drone_storage_path, drone_id)
+        path = os.path.join(self.drone_storage_path, drone_id, "hsv.jpg")
         img.save(path, format="JPEG")
 
     def run_hsv_filter(self, image_np, cpt_config):

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -28,7 +28,7 @@ from gabriel_protocol import gabriel_pb2
 import protocol.common_pb2 as common
 import protocol.controlplane_pb2 as control_plane
 import protocol.gabriel_extras_pb2 as gabriel_extras
-from PIL import Image, ImageDraw
+from PIL import Image
 import traceback
 import json
 from scipy.spatial.transform import Rotation as R

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -41,10 +41,11 @@ import protocol.gabriel_extras_pb2 as gabriel_extras
 
 logger = logging.getLogger(__name__)
 
-class PytorchPredictor():
+
+class PytorchPredictor:
     def __init__(self, model, threshold):
-        path_prefix = './model/'
-        model_path = path_prefix + model + '.pt'
+        path_prefix = "./model/"
+        model_path = path_prefix + model + ".pt"
         logger.info(f"Loading new model {model} at {model_path}...")
         self.detection_model = self.load_model(model_path)
         self.detection_model.conf = threshold
@@ -58,6 +59,7 @@ class PytorchPredictor():
     def infer(self, image):
         return self.model(image)
 
+
 class OpenScoutObjectEngine(cognitive_engine.Engine):
     ENGINE_NAME = "openscout-object"
 
@@ -67,10 +69,16 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         self.store_detections = args.store
         self.model = args.model
         self.drone_type = args.drone
-        self.r = redis.Redis(host='redis', port=args.redis, username='steeleagle', password=f'{args.auth}',decode_responses=True)
+        self.r = redis.Redis(
+            host="redis",
+            port=args.redis,
+            username="steeleagle",
+            password=f"{args.auth}",
+            decode_responses=True,
+        )
         self.r.ping()
         logger.info(f"Connected to redis on port {args.redis}...")
-        #timing vars
+        # timing vars
         self.count = 0
         self.lasttime = time.time()
         self.lastcount = 0
@@ -86,71 +94,93 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         if not os.path.exists(fence_path) or not os.path.isfile(fence_path):
             logger.error(f"Geofence KML file not found or is not a file: {fence_path}")
         else:
-            #build geofence from coordinates inside Polygon element of KML file
-            with open(f"{fence_path}", 'r', encoding='utf-8') as f:
+            # build geofence from coordinates inside Polygon element of KML file
+            with open(f"{fence_path}", "r", encoding="utf-8") as f:
                 root = parser.parse(f).getroot()
                 coords = root.Document.Placemark.Polygon.outerBoundaryIs.LinearRing.coordinates.text
                 for c in coords.split():
-                    lon, lat, alt =  c.split(",")
+                    lon, lat, alt = c.split(",")
                     p = LatLon(lat, lon)
                     self.geofence.append(p)
 
             logger.info(f"GeoFence read: {self.geofence}")
 
-
         if args.exclude:
-            self.exclusions = list(map(int, args.exclude.split(","))) #split string to int list
+            self.exclusions = list(
+                map(int, args.exclude.split(","))
+            )  # split string to int list
             logger.info("Excluding the following class ids: {}".format(self.exclusions))
         else:
             self.exclusions = None
 
-        logger.info("Predictor initialized with the following model path: {}".format(args.model))
+        logger.info(
+            "Predictor initialized with the following model path: {}".format(args.model)
+        )
         logger.info("Confidence Threshold: {}".format(self.threshold))
 
         if self.store_detections:
-            self.watermark = Image.open(os.getcwd()+"/watermark.png")
-            self.storage_path = os.getcwd()+"/images/"
+            self.watermark = Image.open(os.getcwd() + "/watermark.png")
+            self.storage_path = os.getcwd() + "/images/"
             try:
-                os.makedirs(self.storage_path+"/detected")
+                os.makedirs(self.storage_path + "/detected")
             except FileExistsError:
                 logger.info("Images directory already exists.")
             logger.info("Storing detection images at {}".format(self.storage_path))
 
-            self.drone_storage_path = os.path.join(self.storage_path, "detected", "drones")
-            self.class_storage_path = os.path.join(self.storage_path, "detected", "classes")
+            self.drone_storage_path = os.path.join(
+                self.storage_path, "detected", "drones"
+            )
+            self.class_storage_path = os.path.join(
+                self.storage_path, "detected", "classes"
+            )
             try:
                 os.makedirs(self.drone_storage_path)
                 os.makedirs(self.class_storage_path)
             except FileExistsError:
                 pass
 
-        logger.info(f"Search radius when considering duplicate detections: {self.search_radius}")
+        logger.info(
+            f"Search radius when considering duplicate detections: {self.search_radius}"
+        )
 
     def find_intersection(self, target_dir, target_insct):
         plane_pt = np.array([0, 0, 0])
         plane_norm = np.array([0, 0, 1])
 
-        if (plane_norm.dot(target_dir).all() == 0):
+        if plane_norm.dot(target_dir).all() == 0:
             return None
 
-        t = (plane_norm.dot(plane_pt) - plane_norm.dot(target_insct)) / plane_norm.dot(target_dir)
+        t = (plane_norm.dot(plane_pt) - plane_norm.dot(target_insct)) / plane_norm.dot(
+            target_dir
+        )
         return target_insct + (t * target_dir)
 
     def calculate_target_pitch_yaw(self, box, image_np, telemetry):
         img_width = image_np.shape[1]
         img_height = image_np.shape[0]
         pixel_center = (img_width / 2, img_height / 2)
-        logger.info("Image Width: {0}px, Image Height: {1}px, Center {2}".format(img_width, img_height, pixel_center))
-        #eventually these should come from something like a drone .cap file
-        HFOV = 69 # Horizontal FOV An.
-        VFOV = 43 # Vertical FOV.
+        logger.info(
+            "Image Width: {0}px, Image Height: {1}px, Center {2}".format(
+                img_width, img_height, pixel_center
+            )
+        )
+        # eventually these should come from something like a drone .cap file
+        HFOV = 69  # Horizontal FOV An.
+        VFOV = 43  # Vertical FOV.
 
         target_x_pix = img_width - int(((box[3] - box[1]) / 2.0) + box[1])
-        target_y_pix = img_height - int(box[0]) #int(((box[2] - box[0]) / 2.0) + box[0])
-        target_yaw_angle = ((target_x_pix - pixel_center[0]) / pixel_center[0]) * (HFOV / 2)
-        target_pitch_angle = ((target_y_pix - pixel_center[1]) / pixel_center[1]) * (VFOV / 2)
-        target_bottom_pitch_angle = (((img_height - box[2]) - pixel_center[1]) \
-                / pixel_center[1]) * (VFOV / 2)
+        target_y_pix = img_height - int(
+            box[0]
+        )  # int(((box[2] - box[0]) / 2.0) + box[0])
+        target_yaw_angle = ((target_x_pix - pixel_center[0]) / pixel_center[0]) * (
+            HFOV / 2
+        )
+        target_pitch_angle = ((target_y_pix - pixel_center[1]) / pixel_center[1]) * (
+            VFOV / 2
+        )
+        target_bottom_pitch_angle = (
+            ((img_height - box[2]) - pixel_center[1]) / pixel_center[1]
+        ) * (VFOV / 2)
 
         gimbal_pitch = telemetry.gimbal_pose.pitch
 
@@ -159,11 +189,15 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
     def estimate_gps(self, lat, lon, pitch, yaw, alt):
         EARTH_RADIUS = 6378137.0
         vf = [0, 1, 0]
-        r = R.from_euler('ZYX', [yaw, 0, pitch], degrees=True)
+        r = R.from_euler("ZYX", [yaw, 0, pitch], degrees=True)
         target_dir = r.as_matrix().dot(vf)
         target_vec = self.find_intersection(target_dir, np.array([0, 0, alt]))
 
-        logger.info("Intersection with ground plane: ({0}, {1}, {2})".format(target_vec[0], target_vec[1], target_vec[2]))
+        logger.info(
+            "Intersection with ground plane: ({0}, {1}, {2})".format(
+                target_vec[0], target_vec[1], target_vec[2]
+            )
+        )
 
         est_lat = lat + (180 / np.pi) * (target_vec[1] / EARTH_RADIUS)
         est_lon = lon + (180 / np.pi) * (target_vec[0] / EARTH_RADIUS) / np.cos(lat)
@@ -200,19 +234,30 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         self.r.expire(object_key, self.ttl_secs)
         logger.debug(f"Updating {object_key} status: last_seen: {time.time()}")
 
-    def passes_hsv_filter(self, image, bbox, hsv_min=[30,100,100], hsv_max=[50,255,255], threshold=5.0,) -> bool:
-        cropped = image[round(bbox[0]):round(bbox[2]), round(bbox[1]):round(bbox[3])]
+    def passes_hsv_filter(
+        self,
+        image,
+        bbox,
+        hsv_min=[30, 100, 100],
+        hsv_max=[50, 255, 255],
+        threshold=5.0,
+    ) -> bool:
+        cropped = image[
+            round(bbox[0]) : round(bbox[2]), round(bbox[1]) : round(bbox[3])
+        ]
         hsv = cv2.cvtColor(cropped, cv2.COLOR_RGB2HSV)
         lower_boundary = np.array(hsv_min)
         upper_boundary = np.array(hsv_max)
         mask = cv2.inRange(hsv, lower_boundary, upper_boundary)
         cv2.bitwise_and(cropped, cropped, mask=mask)
         percent = round(np.count_nonzero(mask) / np.size(mask) * 100, 2)
-        logger.debug(f"HSV Filter Result: lower_bound:{hsv_min}, upper_bound:{hsv_max}, mask percentage:{percent}%")
-        return (percent >= threshold)
+        logger.debug(
+            f"HSV Filter Result: lower_bound:{hsv_min}, upper_bound:{hsv_max}, mask percentage:{percent}%"
+        )
+        return percent >= threshold
 
     def load_model(self, model_name):
-        path = './model/'+ model_name + '.pt'
+        path = "./model/" + model_name + ".pt"
         if not os.path.exists(path):
             logger.error(f"Model {path} not found. Sticking with previous model.")
         else:
@@ -221,32 +266,34 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
 
     def handle(self, input_frame):
         if input_frame.payload_type == gabriel_pb2.PayloadType.TEXT:
-            #if the payload is TEXT, say from a CNC client, we ignore
+            # if the payload is TEXT, say from a CNC client, we ignore
             status = gabriel_pb2.ResultWrapper.Status.WRONG_INPUT_FORMAT
             result_wrapper = cognitive_engine.create_result_wrapper(status)
             result_wrapper.result_producer_name.value = self.ENGINE_NAME
             result = gabriel_pb2.ResultWrapper.Result()
             result.payload_type = gabriel_pb2.PayloadType.TEXT
-            result.payload = 'Ignoring TEXT payload.'.encode(encoding="utf-8")
+            result.payload = "Ignoring TEXT payload.".encode(encoding="utf-8")
             result_wrapper.results.append(result)
             return result_wrapper
 
         extras = cognitive_engine.unpack_extras(gabriel_extras.Extras, input_frame)
 
-        if not extras.cpt_request.HasField('cpt'):
+        if not extras.cpt_request.HasField("cpt"):
             logger.error("Compute configuration not found")
             status = gabriel_pb2.ResultWrapper.Status.UNSPECIFIED_ERROR
             result_wrapper = cognitive_engine.create_result_wrapper(status)
             result_wrapper.result_producer_name.value = self.ENGINE_NAME
             result = gabriel_pb2.ResultWrapper.Result()
             result.payload_type = gabriel_pb2.PayloadType.TEXT
-            result.payload = 'Expected compute configuration to be specified'.encode(encoding="utf-8")
+            result.payload = "Expected compute configuration to be specified".encode(
+                encoding="utf-8"
+            )
             result_wrapper.results.append(result)
             return result_wrapper
 
         cpt_config = extras.cpt_request.cpt
 
-        if cpt_config.model != '' and cpt_config.model != self.model:
+        if cpt_config.model != "" and cpt_config.model != self.model:
             self.load_model(cpt_config.model)
 
         self.t0 = time.time()
@@ -261,7 +308,8 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                 results,
                 cpt_config,
                 extras.telemetry,
-                extras.telemetry.drone_name)
+                extras.telemetry.drone_name,
+            )
 
             if gabriel_result is not None:
                 result_wrapper.results.append(gabriel_result)
@@ -282,12 +330,12 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         return result_wrapper
 
     def process_results(self, image_np, results, cpt_config, telemetry, drone_id):
-        df = results[0].to_df() # pandas dataframe
-        #convert dataframe to python lists
+        df = results[0].to_df()  # pandas dataframe
+        # convert dataframe to python lists
         if df.size > 0:
-            classes = df['class'].values.tolist()
-            scores = df['confidence'].values.tolist()
-            names = df['name'].values.tolist()
+            classes = df["class"].values.tolist()
+            scores = df["confidence"].values.tolist()
+            names = df["name"].values.tolist()
         else:
             classes = []
             scores = []
@@ -301,11 +349,13 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         timestamp_millis = int(time.time() * 1000)
         filename = str(timestamp_millis) + ".jpg"
         if self.store_detections:
-            detection_url = os.path.join(os.environ["WEBSERVER"], "detected", "drones", drone_id, filename)
+            detection_url = os.path.join(
+                os.environ["WEBSERVER"], "detected", "drones", drone_id, filename
+            )
         else:
             detection_url = ""
 
-        run_hsv_filter = cpt_config.HasField('lower_bound')
+        run_hsv_filter = cpt_config.HasField("lower_bound")
 
         for i in range(0, len(classes)):
             if self.exclusions is not None and classes[i] in self.exclusions:
@@ -313,11 +363,13 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
 
             if scores[i] > self.threshold:
                 detections_above_threshold = True
-                logger.info("Detected : {} - Score: {:.3f}".format(names[i],scores[i]))
+                logger.info("Detected : {} - Score: {:.3f}".format(names[i], scores[i]))
 
                 box = df["box"][i]
-                box = [box['y1'], box['x1'], box['y2'], box['x2']]
-                target_pitch, target_yaw = self.calculate_target_pitch_yaw(box, image_np, telemetry)
+                box = [box["y1"], box["x1"], box["y2"], box["x2"]]
+                target_pitch, target_yaw = self.calculate_target_pitch_yaw(
+                    box, image_np, telemetry
+                )
 
                 # Estimate GPS coordinates of detected object
                 position = telemetry.global_position
@@ -326,7 +378,8 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                     position.longitude,
                     target_pitch,
                     target_yaw,
-                    telemetry.relative_position.up)
+                    telemetry.relative_position.up,
+                )
 
                 lon = np.clip(lon, -180, 180)
                 lat = np.clip(lat, -85, 85)
@@ -343,7 +396,8 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                         box,
                         lower_bound,
                         upper_bound,
-                        threshold=self.hsv_threshold)
+                        threshold=self.hsv_threshold,
+                    )
 
                 detection = {
                     "id": drone_id,
@@ -352,12 +406,14 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                     "lat": lat,
                     "lon": lon,
                     "box": box,
-                    "hsv_filter": hsv_filter_passed
+                    "hsv_filter": hsv_filter_passed,
                 }
 
                 if not self.geofence_enabled:
                     detections.append(detection)
-                    self.store_detection_db(drone_id, lat, lon, names[i], scores[i], detection_url)
+                    self.store_detection_db(
+                        drone_id, lat, lon, names[i], scores[i], detection_url
+                    )
                     continue
 
                 # if there is no geofence, or the estimated object location is within the geofence...
@@ -365,7 +421,15 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                     passed, prev_obj = self.geofilter_passed(detection)
                     if passed:
                         detections.append(detection)
-                        self.store_detection_db(drone_id, lat, lon, names[i], scores[i], detection_url, prev_obj)
+                        self.store_detection_db(
+                            drone_id,
+                            lat,
+                            lon,
+                            names[i],
+                            scores[i],
+                            detection_url,
+                            prev_obj,
+                        )
 
         if len(detections) == 0:
             return None
@@ -385,7 +449,9 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
                 im_bgr = results[0].plot()
                 self.store_detections_disk(im_bgr, filename, drone_id, set(names))
             except IndexError:
-                logger.error(f"IndexError while getting bounding boxes [{traceback.format_exc()}]")
+                logger.error(
+                    f"IndexError while getting bounding boxes [{traceback.format_exc()}]"
+                )
 
         return gabriel_result if detections_above_threshold else None
 
@@ -423,8 +489,20 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
 
     def run_hsv_filter(self, image_np, cpt_config):
         hsv = cv2.cvtColor(image_np, cv2.COLOR_RGB2HSV)
-        lower_boundary = np.array([cpt_config.lower_bound.h, cpt_config.lower_bound.s, cpt_config.lower_bound.v])
-        upper_boundary = np.array([cpt_config.upper_bound.h, cpt_config.upper_bound.s, cpt_config.upper_bound.v])
+        lower_boundary = np.array(
+            [
+                cpt_config.lower_bound.h,
+                cpt_config.lower_bound.s,
+                cpt_config.lower_bound.v,
+            ]
+        )
+        upper_boundary = np.array(
+            [
+                cpt_config.upper_bound.h,
+                cpt_config.upper_bound.s,
+                cpt_config.upper_bound.v,
+            ]
+        )
         mask = cv2.inRange(hsv, lower_boundary, upper_boundary)
         final = cv2.bitwise_and(hsv, hsv, mask=mask)
         final = cv2.cvtColor(final, cv2.COLOR_HSV2RGB)
@@ -434,7 +512,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         self.t0 = time.time()
         np_data = np.fromstring(image, dtype=np.uint8)
         img = cv2.imdecode(np_data, cv2.IMREAD_COLOR)
-        #img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        # img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
         results = self.inference(img)
         self.t1 = time.time()
@@ -458,7 +536,9 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             unit="m",
         )
         if len(objects) == 0:
-            logger.info(f"Adding detection for {cls} for drone {drone_id} for the first time")
+            logger.info(
+                f"Adding detection for {cls} for drone {drone_id} for the first time"
+            )
             return (True, None)
 
         logger.info(f"Objects already exist within search radius: {objects}")
@@ -467,10 +547,14 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
             d = self.r.hgetall(f"objects:{obj}")
             if d and d["cls"] == cls:
                 if d["drone_id"] == drone_id:
-                    logger.debug(f"Drone {d['drone_id']} detected {obj} in same area, updating obj location")
+                    logger.debug(
+                        f"Drone {d['drone_id']} detected {obj} in same area, updating obj location"
+                    )
                     return (True, obj)
                 else:
-                    logger.info(f"Ignoring detection, {obj} already found by drone {d['drone_id']}")
+                    logger.info(
+                        f"Ignoring detection, {obj} already found by drone {d['drone_id']}"
+                    )
                     return (False, None)
         return (True, None)
 
@@ -488,5 +572,6 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
 
     def inference(self, img):
         """Allow timing engine to override this"""
-        return self.detector.detection_model.predict(img, conf=self.threshold, verbose=False)
-
+        return self.detector.detection_model.predict(
+            img, conf=self.threshold, verbose=False
+        )

--- a/backend/server/engines/detection/openscout_object_engine.py
+++ b/backend/server/engines/detection/openscout_object_engine.py
@@ -284,7 +284,7 @@ class OpenScoutObjectEngine(cognitive_engine.Engine):
         timestamp_millis = int(time.time() * 1000)
         filename = str(timestamp_millis) + ".jpg"
         if self.store_detections:
-            detection_url = os.path.join(os.environ["WEBSERVER"], "detected", filename)
+            detection_url = os.path.join(os.environ["WEBSERVER"], "detected", "drones", drone_id, filename)
         else:
             detection_url = ""
 

--- a/backend/server/engines/gabriel-server/main.py
+++ b/backend/server/engines/gabriel-server/main.py
@@ -5,9 +5,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-from gabriel_server.network_engine import server_runner
-import logging
 import argparse
+import logging
+
+from gabriel_server.network_engine import server_runner
 from util.utils import setup_logging
 
 DEFAULT_PORT = 9099

--- a/backend/server/engines/gabriel-server/main.py
+++ b/backend/server/engines/gabriel-server/main.py
@@ -17,6 +17,7 @@ INPUT_QUEUE_MAXSIZE = 60
 
 logger = logging.getLogger(__name__)
 
+
 def main():
     setup_logging(logger)
     parser = argparse.ArgumentParser(
@@ -31,16 +32,27 @@ def main():
     )
 
     parser.add_argument(
-        "-q", "--queue", type=int, default=INPUT_QUEUE_MAXSIZE, help="Max input queue size"
+        "-q",
+        "--queue",
+        type=int,
+        default=INPUT_QUEUE_MAXSIZE,
+        help="Max input queue size",
     )
 
     parser.add_argument(
-        "-z", "--zmq", action="store_true", help="Use ZeroMQ Gabriel client")
+        "-z", "--zmq", action="store_true", help="Use ZeroMQ Gabriel client"
+    )
 
     args, _ = parser.parse_known_args()
 
-    server_runner.run(websocket_port=args.port, zmq_address='tcp://*:5555', num_tokens=args.tokens,
-                  input_queue_maxsize=args.queue, use_zeromq=args.zmq)
+    server_runner.run(
+        websocket_port=args.port,
+        zmq_address="tcp://*:5555",
+        num_tokens=args.tokens,
+        input_queue_maxsize=args.queue,
+        use_zeromq=args.zmq,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/backend/server/engines/slam/slam.py
+++ b/backend/server/engines/slam/slam.py
@@ -18,10 +18,11 @@
 #   limitations under the License.
 #
 #
+import argparse
+import logging
+
 from gabriel_server.network_engine import engine_runner
 from terraslam import TerraSLAMEngine
-import logging
-import argparse
 from util.utils import setup_logging
 
 SOURCE = 'telemetry'

--- a/backend/server/engines/slam/slam.py
+++ b/backend/server/engines/slam/slam.py
@@ -25,9 +25,10 @@ from gabriel_server.network_engine import engine_runner
 from terraslam import TerraSLAMEngine
 from util.utils import setup_logging
 
-SOURCE = 'telemetry'
+SOURCE = "telemetry"
 
 logger = logging.getLogger(__name__)
+
 
 def main():
     setup_logging(logger)
@@ -35,9 +36,7 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    parser.add_argument(
-        "-p", "--port", type=int, default=9099, help="Set port number"
-    )
+    parser.add_argument("-p", "--port", type=int, default=9099, help="Set port number")
 
     parser.add_argument(
         "-s", "--server", default="128.2.208.19", help="SLAM container IP address"
@@ -47,16 +46,17 @@ def main():
     #     "-t", "--transform", default="transform.json", help="Path to transform.json file"
     # )
 
-    parser.add_argument(
-        "-R", "--redis", type=int, default=6379, help="Redis port"
-    )
+    parser.add_argument("-R", "--redis", type=int, default=6379, help="Redis port")
 
     parser.add_argument(
         "-a", "--auth", default="", help="Redis authentication password"
     )
 
     parser.add_argument(
-        "-g", "--gabriel", default="tcp://gabriel-server:5555", help="Gabriel server endpoint"
+        "-g",
+        "--gabriel",
+        default="tcp://gabriel-server:5555",
+        help="Gabriel server endpoint",
     )
 
     parser.add_argument(
@@ -73,8 +73,9 @@ def main():
         engine=engine_setup(),
         source_name=args.source,
         server_address=args.gabriel,
-        all_responses_required=True
+        all_responses_required=True,
     )
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/backend/server/engines/slam/slam_test_client.py
+++ b/backend/server/engines/slam/slam_test_client.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 import argparse
+import asyncio
 import logging
 import os
-import cv2
-import asyncio
 import time
-from gabriel_protocol import gabriel_pb2
-from gabriel_client.zeromq_client import ProducerWrapper, ZeroMQClient
+
+import cv2
 import gabriel_extras_pb2 as gabriel_extras
+from gabriel_client.zeromq_client import ProducerWrapper, ZeroMQClient
+from gabriel_protocol import gabriel_pb2
 
 logging.basicConfig(level=logging.DEBUG) 
 logger = logging.getLogger(__name__)

--- a/backend/server/engines/slam/slam_test_client.py
+++ b/backend/server/engines/slam/slam_test_client.py
@@ -10,24 +10,36 @@ import gabriel_extras_pb2 as gabriel_extras
 from gabriel_client.zeromq_client import ProducerWrapper, ZeroMQClient
 from gabriel_protocol import gabriel_pb2
 
-logging.basicConfig(level=logging.DEBUG) 
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
+
 class SlamZeroMQClient:
-    def __init__(self, image_path, server="gabriel-server", port=9099, source_name="telemetry", client_id="slam_client"):
+    def __init__(
+        self,
+        image_path,
+        server="gabriel-server",
+        port=9099,
+        source_name="telemetry",
+        client_id="slam_client",
+    ):
         self.source_name = source_name
         self.server = server
         self.port = port
         self.client_id = client_id
-        
+
         # Store the latest results from each engine
         self.engine_results = {}
-        
+
         # Setup image source
         if os.path.isdir(image_path):
-            self.image_files = sorted([os.path.join(image_path, f)
-                                      for f in os.listdir(image_path)
-                                      if f.lower().endswith(('.png', '.jpg', '.jpeg'))])
+            self.image_files = sorted(
+                [
+                    os.path.join(image_path, f)
+                    for f in os.listdir(image_path)
+                    if f.lower().endswith((".png", ".jpg", ".jpeg"))
+                ]
+            )
             if not self.image_files:
                 raise ValueError(f"No image files found in {image_path}")
             logger.info(f"Found {len(self.image_files)} images")
@@ -38,47 +50,50 @@ class SlamZeroMQClient:
             if self.image is None:
                 raise ValueError(f"Cannot read {image_path}")
             self.is_dir = False
-        
+
         # Setup ZeroMQ client
         self.gabriel_client = ZeroMQClient(
-            self.server, self.port,
-            [self.get_image_producer()], self.process_results
+            self.server, self.port, [self.get_image_producer()], self.process_results
         )
 
     def process_results(self, result_wrapper):
         if len(result_wrapper.results) == 0:
             return
-            
+
         # Get engine ID
         engine_id = result_wrapper.result_producer_name.value
-        logger.info(f"Received {len(result_wrapper.results)} results from engine: {engine_id}")
-        
+        logger.info(
+            f"Received {len(result_wrapper.results)} results from engine: {engine_id}"
+        )
+
         # Process each result
         for result in result_wrapper.results:
             if result.payload_type == gabriel_pb2.PayloadType.TEXT:
-                payload = result.payload.decode('utf-8')
+                payload = result.payload.decode("utf-8")
                 # Save result for the corresponding engine
                 timestamp = time.time()
                 self.engine_results[engine_id] = {
-                    'payload': payload,
-                    'timestamp': timestamp
+                    "payload": payload,
+                    "timestamp": timestamp,
                 }
-                
+
                 # Process results differently based on engine type
                 if "terra-slam" in engine_id.lower():
                     logger.info(f"SLAM result: {payload}")
                 # else:
                 #     logger.debug(f"Other engine result ({engine_id}): {payload}")
             else:
-                logger.info(f"Got non-text result type {result.payload_type} from {engine_id}")
-    
+                logger.info(
+                    f"Got non-text result type {result.payload_type} from {engine_id}"
+                )
+
     def get_image_producer(self):
         async def producer():
             await asyncio.sleep(0.1)
-            
+
             logger.debug(f"Image producer: starting at {time.time()}")
             input_frame = gabriel_pb2.InputFrame()
-            
+
             try:
                 if self.is_dir:
                     img_path = self.image_files[self.idx]
@@ -87,39 +102,43 @@ class SlamZeroMQClient:
                     logger.info(f"Sending {img_path}")
                 else:
                     img = self.image
-                
-                _, jpg_buffer = cv2.imencode('.jpg', img)
+
+                _, jpg_buffer = cv2.imencode(".jpg", img)
                 input_frame.payload_type = gabriel_pb2.PayloadType.IMAGE
                 input_frame.payloads.append(jpg_buffer.tobytes())
-                
+
                 # Add extras similar to GabrielCompute.py
                 extras = gabriel_extras.Extras()
                 # extras.drone_id = self.client_id
                 extras.telemetry.drone_name = self.client_id
-                
+
                 # Add telemetry data (avoid using fields that don't exist)
                 telemetry = extras.telemetry
                 # Only set compatible fields
                 telemetry.uptime.FromSeconds(0)  # Mock uptime
-                
+
                 # Set computation request in the same way as GabrielCompute
                 # Note: In GabrielCompute, compute_id is passed as the key, not specifying a specific engine
                 compute_command = extras.cpt_request
                 compute_command.cpt.model = "terra-slam"  # Request terra-slam engine
-                
+
                 # Pack extras into the input frame
                 input_frame.extras.Pack(extras)
-                
-                logger.debug(f"Image producer: finished preparing frame at {time.time()}")
+
+                logger.debug(
+                    f"Image producer: finished preparing frame at {time.time()}"
+                )
             except Exception as e:
                 input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
-                input_frame.payloads.append(f"Unable to produce a frame: {e}".encode('utf-8'))
-                logger.error(f'Image producer: unable to produce a frame: {e}')
-                
+                input_frame.payloads.append(
+                    f"Unable to produce a frame: {e}".encode("utf-8")
+                )
+                logger.error(f"Image producer: unable to produce a frame: {e}")
+
             return input_frame
-            
+
         return ProducerWrapper(producer=producer, source_name=self.source_name)
-    
+
     def print_all_results(self):
         """Print the latest results from all engines"""
         logger.info("==== Current Results from All Engines ====")
@@ -127,11 +146,12 @@ class SlamZeroMQClient:
             logger.info(f"Engine: {engine}, Time: {data['timestamp']}")
             logger.info(f"Payload: {data['payload'][:100]}...")
         logger.info("=========================================")
-    
+
     async def run(self):
         logger.info(f"Starting ZeroMQ client connecting to {self.server}:{self.port}")
         logger.info("Will collect results from all available engines")
         await self.gabriel_client.launch_async()
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -139,7 +159,9 @@ def main():
     ap.add_argument("-s", "--server", default="gabriel-server", help="server host")
     ap.add_argument("-p", "--port", type=int, default=9099, help="server port")
     ap.add_argument("-n", "--name", default="telemetry", help="source name")
-    ap.add_argument("-c", "--client_id", default="slam_client", help="client id for drone_id")
+    ap.add_argument(
+        "-c", "--client_id", default="slam_client", help="client id for drone_id"
+    )
     args = ap.parse_args()
 
     client = SlamZeroMQClient(
@@ -147,10 +169,11 @@ def main():
         server=args.server,
         port=args.port,
         source_name=args.name,
-        client_id=args.client_id
+        client_id=args.client_id,
     )
-    
+
     asyncio.run(client.run())
+
 
 if __name__ == "__main__":
     main()

--- a/backend/server/engines/slam/slam_test_client.py
+++ b/backend/server/engines/slam/slam_test_client.py
@@ -130,9 +130,7 @@ class SlamZeroMQClient:
                 )
             except Exception as e:
                 input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
-                input_frame.payloads.append(
-                    f"Unable to produce a frame: {e}".encode("utf-8")
-                )
+                input_frame.payloads.append(f"Unable to produce a frame: {e}".encode())
                 logger.error(f"Image producer: unable to produce a frame: {e}")
 
             return input_frame

--- a/backend/server/engines/slam/slam_test_client.py
+++ b/backend/server/engines/slam/slam_test_client.py
@@ -8,7 +8,6 @@ import time
 from gabriel_protocol import gabriel_pb2
 from gabriel_client.zeromq_client import ProducerWrapper, ZeroMQClient
 import gabriel_extras_pb2 as gabriel_extras
-from gabriel_server import cognitive_engine
 
 logging.basicConfig(level=logging.DEBUG) 
 logger = logging.getLogger(__name__)
@@ -130,7 +129,7 @@ class SlamZeroMQClient:
     
     async def run(self):
         logger.info(f"Starting ZeroMQ client connecting to {self.server}:{self.port}")
-        logger.info(f"Will collect results from all available engines")
+        logger.info("Will collect results from all available engines")
         await self.gabriel_client.launch_async()
 
 def main():

--- a/backend/server/engines/slam/terraslam.py
+++ b/backend/server/engines/slam/terraslam.py
@@ -21,11 +21,9 @@
 import socket
 import struct
 import cv2
-import os
 import time
 import logging
 import json
-from pathlib import Path
 import numpy as np
 import redis
 from gabriel_server import cognitive_engine

--- a/backend/server/engines/slam/terraslam.py
+++ b/backend/server/engines/slam/terraslam.py
@@ -161,9 +161,7 @@ class TerraSLAMEngine(cognitive_engine.Engine):
             result_wrapper = self.get_result_wrapper(status)
             result = gabriel_pb2.ResultWrapper.Result()
             result.payload_type = gabriel_pb2.PayloadType.TEXT
-            result.payload = "Expected compute configuration to be specified".encode(
-                encoding="utf-8"
-            )
+            result.payload = b"Expected compute configuration to be specified"
             result_wrapper.results.append(result)
             return result_wrapper
 
@@ -240,7 +238,7 @@ class TerraSLAMEngine(cognitive_engine.Engine):
 
         result = gabriel_pb2.ResultWrapper.Result()
         result.payload_type = gabriel_pb2.PayloadType.TEXT
-        result.payload = "Ignoring TEXT payload.".encode(encoding="utf-8")
+        result.payload = b"Ignoring TEXT payload."
         result_wrapper.results.append(result)
         return result_wrapper
 
@@ -251,14 +249,10 @@ class TerraSLAMEngine(cognitive_engine.Engine):
 
     def print_inference_stats(self):
         current_time = time.time()
+        logger.info(f"inference time {(current_time - self.lasttime) * 1000:.1f} ms, ")
+        logger.info(f"fps {1.0 / (current_time - self.lasttime):.2f}")
         logger.info(
-            "inference time {0:.1f} ms, ".format((current_time - self.lasttime) * 1000)
-        )
-        logger.info("fps {0:.2f}".format(1.0 / (current_time - self.lasttime)))
-        logger.info(
-            "avg fps: {0:.2f}".format(
-                (self.count - self.lastcount) / (current_time - self.lastprint)
-            )
+            f"avg fps: {(self.count - self.lastcount) / (current_time - self.lastprint):.2f}"
         )
         self.lastcount = self.count
         self.lasttime = current_time

--- a/backend/server/engines/slam/terraslam.py
+++ b/backend/server/engines/slam/terraslam.py
@@ -18,19 +18,22 @@
 #   limitations under the License.
 #
 #
+import json
+import logging
 import socket
 import struct
-import cv2
 import time
-import logging
-import json
+
+import cv2
 import numpy as np
 import redis
-from gabriel_server import cognitive_engine
 from gabriel_protocol import gabriel_pb2
+from gabriel_server import cognitive_engine
+
 import protocol.common_pb2 as common
 import protocol.controlplane_pb2 as control_plane
 import protocol.gabriel_extras_pb2 as gabriel_extras
+
 logger = logging.getLogger(__name__)
 
 class TerraSLAMClient:

--- a/backend/server/engines/swarm_controller/mission_supervisor_test.py
+++ b/backend/server/engines/swarm_controller/mission_supervisor_test.py
@@ -9,6 +9,7 @@ import protocol.controlplane_pb2 as controlplane
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
+
 class FakeSocket:
     def __init__(self):
         self.sent_msgs = []
@@ -33,19 +34,22 @@ class FakeSocket:
             response.resp = common.ResponseStatus.COMPLETED  # Then finish
 
         # Always return drone1 to avoid index errors
-        identity = b'drone1'
+        identity = b"drone1"
         self.recv_count += 1
 
         return [identity, response.SerializeToString()]
 
+
 async def test_mission_supervisor_single_drone():
     logger.info("=== Test: MissionSupervisor Single Drone ===")
 
-    patrol_area_list = await PatrolArea.load_from_file('test')
+    patrol_area_list = await PatrolArea.load_from_file("test")
     print(f"Patrol area list: {patrol_area_list}")
 
     # Setup StaticPatrolMission with one drone
-    mission = StaticPatrolMission(drone_list=["drone1"], patrol_area_list=patrol_area_list, alt=10)
+    mission = StaticPatrolMission(
+        drone_list=["drone1"], patrol_area_list=patrol_area_list, alt=10
+    )
 
     # Use FakeSocket for testing
     fake_socket = FakeSocket()
@@ -62,5 +66,6 @@ async def test_mission_supervisor_single_drone():
     for msg in fake_socket.sent_msgs:
         logger.info(f"Sent: {msg}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(test_mission_supervisor_single_drone())

--- a/backend/server/engines/swarm_controller/mission_supervisor_test.py
+++ b/backend/server/engines/swarm_controller/mission_supervisor_test.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
-from swarm_controller import PatrolArea, StaticPatrolMission, MissionSupervisor
-import protocol.controlplane_pb2 as controlplane
+
+from swarm_controller import MissionSupervisor, PatrolArea, StaticPatrolMission
+
 import protocol.common_pb2 as common
+import protocol.controlplane_pb2 as controlplane
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/backend/server/engines/swarm_controller/patrol_mission_test.py
+++ b/backend/server/engines/swarm_controller/patrol_mission_test.py
@@ -1,5 +1,4 @@
 from swarm_controller import PatrolArea, PatrolMission
-import pytest_asyncio
 import pytest
 
 @pytest.mark.asyncio
@@ -24,19 +23,19 @@ async def test_mission_creation():
 
     drone_id, waypoints = mission.state_transition('d1', None)
     assert drone_id == 'd1'
-    assert waypoints.waypoints == f"Hex.Hex_1"
+    assert waypoints.waypoints == "Hex.Hex_1"
 
     drone_id, waypoints = mission.state_transition('d1', None)
     assert drone_id == 'd1'
-    assert waypoints.waypoints == f"Hex.Hex_2"
+    assert waypoints.waypoints == "Hex.Hex_2"
 
     drone_id, waypoints = mission.state_transition('d2', None)
     assert drone_id == 'd2'
-    assert waypoints.waypoints == f"Hex.Hex_9"
+    assert waypoints.waypoints == "Hex.Hex_9"
 
     drone_id, waypoints = mission.state_transition('d3', None)
     assert drone_id == 'd3'
-    assert waypoints.waypoints == f"Hex.Hex_17"
+    assert waypoints.waypoints == "Hex.Hex_17"
 
     for i in range(8):
         drone_id, waypoints = mission.state_transition('d3', None)
@@ -45,7 +44,7 @@ async def test_mission_creation():
 
     drone_id, waypoints = mission.state_transition('d3', None)
     assert drone_id == 'd3'
-    assert waypoints.waypoints == f"Hex.Hex_3"
+    assert waypoints.waypoints == "Hex.Hex_3"
 
     for i in range(5):
         drone_id, waypoints = mission.state_transition('d3', None)

--- a/backend/server/engines/swarm_controller/patrol_mission_test.py
+++ b/backend/server/engines/swarm_controller/patrol_mission_test.py
@@ -4,10 +4,10 @@ from swarm_controller import PatrolArea, PatrolMission
 
 @pytest.mark.asyncio
 async def test_mission_creation():
-    patrol_area_list = await PatrolArea.load_from_file('test')
+    patrol_area_list = await PatrolArea.load_from_file("test")
     print(patrol_area_list)
 
-    drone_list = ['d1','d2','d3']
+    drone_list = ["d1", "d2", "d3"]
     mission = PatrolMission(drone_list, patrol_area_list)
     state = mission.get_state()
 
@@ -20,44 +20,43 @@ async def test_mission_creation():
     patrol_waypoints = patrol_area.get_patrol_waypoints()
     assert len(patrol_waypoints) == 25
     for idx, patrol_waypoint in enumerate(patrol_waypoints):
-        assert patrol_waypoint.waypoints == f"Hex.Hex_{idx+1}"
+        assert patrol_waypoint.waypoints == f"Hex.Hex_{idx + 1}"
 
-    drone_id, waypoints = mission.state_transition('d1', None)
-    assert drone_id == 'd1'
+    drone_id, waypoints = mission.state_transition("d1", None)
+    assert drone_id == "d1"
     assert waypoints.waypoints == "Hex.Hex_1"
 
-    drone_id, waypoints = mission.state_transition('d1', None)
-    assert drone_id == 'd1'
+    drone_id, waypoints = mission.state_transition("d1", None)
+    assert drone_id == "d1"
     assert waypoints.waypoints == "Hex.Hex_2"
 
-    drone_id, waypoints = mission.state_transition('d2', None)
-    assert drone_id == 'd2'
+    drone_id, waypoints = mission.state_transition("d2", None)
+    assert drone_id == "d2"
     assert waypoints.waypoints == "Hex.Hex_9"
 
-    drone_id, waypoints = mission.state_transition('d3', None)
-    assert drone_id == 'd3'
+    drone_id, waypoints = mission.state_transition("d3", None)
+    assert drone_id == "d3"
     assert waypoints.waypoints == "Hex.Hex_17"
 
     for i in range(8):
-        drone_id, waypoints = mission.state_transition('d3', None)
-        assert drone_id == 'd3'
-        assert waypoints.waypoints == f"Hex.Hex_{17+i+1}"
+        drone_id, waypoints = mission.state_transition("d3", None)
+        assert drone_id == "d3"
+        assert waypoints.waypoints == f"Hex.Hex_{17 + i + 1}"
 
-    drone_id, waypoints = mission.state_transition('d3', None)
-    assert drone_id == 'd3'
+    drone_id, waypoints = mission.state_transition("d3", None)
+    assert drone_id == "d3"
     assert waypoints.waypoints == "Hex.Hex_3"
 
     for i in range(5):
-        drone_id, waypoints = mission.state_transition('d3', None)
-        assert drone_id == 'd3'
-        assert waypoints.waypoints == f"Hex.Hex_{4+i}"
+        drone_id, waypoints = mission.state_transition("d3", None)
+        assert drone_id == "d3"
+        assert waypoints.waypoints == f"Hex.Hex_{4 + i}"
 
     for i in range(7):
-        drone_id, waypoints = mission.state_transition('d3', None)
-        assert drone_id == 'd3'
-        assert waypoints.waypoints == f"Hex.Hex_{10+i}"
+        drone_id, waypoints = mission.state_transition("d3", None)
+        assert drone_id == "d3"
+        assert waypoints.waypoints == f"Hex.Hex_{10 + i}"
 
-    drone_id, waypoints = mission.state_transition('d3', None)
-    assert drone_id == 'd3'
+    drone_id, waypoints = mission.state_transition("d3", None)
+    assert drone_id == "d3"
     assert waypoints == "finish"
-

--- a/backend/server/engines/swarm_controller/patrol_mission_test.py
+++ b/backend/server/engines/swarm_controller/patrol_mission_test.py
@@ -1,5 +1,6 @@
-from swarm_controller import PatrolArea, PatrolMission
 import pytest
+from swarm_controller import PatrolArea, PatrolMission
+
 
 @pytest.mark.asyncio
 async def test_mission_creation():

--- a/backend/server/engines/swarm_controller/swarm_controller.py
+++ b/backend/server/engines/swarm_controller/swarm_controller.py
@@ -6,12 +6,10 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 import os
-import subprocess
 import logging
 from zipfile import ZipFile
 from google.protobuf.message import DecodeError
 from google.protobuf import text_format
-import requests
 import protocol.controlplane_pb2 as controlplane
 import protocol.common_pb2 as common
 import argparse
@@ -25,7 +23,7 @@ import aiohttp
 import aiofiles
 from dataclasses import dataclass
 import json
-from typing import List, Set, Optional
+from typing import List
 from collections.abc import Iterator
 from abc import ABC, abstractmethod
 

--- a/backend/server/engines/swarm_controller/swarm_controller.py
+++ b/backend/server/engines/swarm_controller/swarm_controller.py
@@ -289,6 +289,10 @@ class SwarmController:
         self.spacing = spacing
         self.angle = angle
 
+        out_dir = '/compiler/out'
+        if not os.path.exists(out_dir):
+            os.makedir(out_dir)
+
     async def run(self):
         await asyncio.gather(self.listen_cmdrs())
 

--- a/backend/server/engines/swarm_controller/swarm_controller.py
+++ b/backend/server/engines/swarm_controller/swarm_controller.py
@@ -5,27 +5,29 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-import os
-import logging
-from zipfile import ZipFile
-from google.protobuf.message import DecodeError
-from google.protobuf import text_format
-import protocol.controlplane_pb2 as controlplane
-import protocol.common_pb2 as common
 import argparse
+import asyncio
+import json
+import logging
+import os
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import List
+from urllib.parse import urlparse
+from zipfile import ZipFile
+
+import aiofiles
+import aiohttp
+import redis
 import zmq
 import zmq.asyncio
-import redis
-from urllib.parse import urlparse
+from google.protobuf import text_format
+from google.protobuf.message import DecodeError
 from util.utils import setup_logging
-import asyncio
-import aiohttp
-import aiofiles
-from dataclasses import dataclass
-import json
-from typing import List
-from collections.abc import Iterator
-from abc import ABC, abstractmethod
+
+import protocol.common_pb2 as common
+import protocol.controlplane_pb2 as controlplane
 
 logger = logging.getLogger(__name__)
 

--- a/backend/server/engines/swarm_controller/swarm_controller.py
+++ b/backend/server/engines/swarm_controller/swarm_controller.py
@@ -13,7 +13,6 @@ import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import List
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
@@ -131,7 +130,7 @@ class PatrolArea:
 
     @staticmethod
     async def load_from_file(filename):
-        async with aiofiles.open(filename, mode="r") as f:
+        async with aiofiles.open(filename) as f:
             contents = await f.read()
         data = json.loads(contents)
 
@@ -159,11 +158,11 @@ class PatrolWaypoints:
 
 @dataclass
 class PatrolMissionState:
-    drone_list: List[str]
-    patrol_area_list: List[PatrolArea]
+    drone_list: list[str]
+    patrol_area_list: list[PatrolArea]
     current_patrol_area: PatrolArea
-    patrol_area_iter: Iterator[List[PatrolArea]]
-    drone_altitudes: List[int]
+    patrol_area_iter: Iterator[list[PatrolArea]]
+    drone_altitudes: list[int]
 
 
 class Mission(ABC):

--- a/backend/server/engines/telemetry/telemetry.py
+++ b/backend/server/engines/telemetry/telemetry.py
@@ -5,10 +5,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
+import argparse
+import logging
+
 from gabriel_server.network_engine import engine_runner
 from telemetry_engine import TelemetryEngine
-import logging
-import argparse
 from util.utils import setup_logging
 
 SOURCE = 'telemetry'

--- a/backend/server/engines/telemetry/telemetry.py
+++ b/backend/server/engines/telemetry/telemetry.py
@@ -12,9 +12,10 @@ from gabriel_server.network_engine import engine_runner
 from telemetry_engine import TelemetryEngine
 from util.utils import setup_logging
 
-SOURCE = 'telemetry'
+SOURCE = "telemetry"
 
 logger = logging.getLogger(__name__)
+
 
 def main():
     setup_logging(logger)
@@ -22,28 +23,35 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
+    parser.add_argument("-p", "--port", type=int, default=9099, help="Set port number")
+
     parser.add_argument(
-        "-p", "--port", type=int, default=9099, help="Set port number"
+        "-g",
+        "--gabriel",
+        default="tcp://gabriel-server:5555",
+        help="Gabriel server endpoint.",
     )
 
     parser.add_argument(
-        "-g", "--gabriel",  default="tcp://gabriel-server:5555", help="Gabriel server endpoint."
+        "-r",
+        "--redis",
+        type=int,
+        default=6379,
+        help="Set port number for redis connection [default: 6379]",
+    )
+
+    parser.add_argument("-a", "--auth", default="", help="Share key for redis user.")
+
+    parser.add_argument(
+        "-l", "--publish", action="store_true", help="Publish incoming images via redis"
     )
 
     parser.add_argument(
-        "-r", "--redis", type=int, default=6379, help="Set port number for redis connection [default: 6379]"
-    )
-
-    parser.add_argument(
-        "-a", "--auth", default="", help="Share key for redis user."
-    )
-
-    parser.add_argument(
-        "-l", "--publish", action='store_true', help="Publish incoming images via redis"
-    )
-
-    parser.add_argument(
-        "-t", "--ttl", type=int, default=7, help="TTL in days before drones status tables are cleaned up in redis [default: 7]"
+        "-t",
+        "--ttl",
+        type=int,
+        default=7,
+        help="TTL in days before drones status tables are cleaned up in redis [default: 7]",
     )
 
     args, _ = parser.parse_known_args()
@@ -52,7 +60,13 @@ def main():
         return TelemetryEngine(args)
 
     logger.info("Starting telemetry cognitive engine..")
-    engine_runner.run(engine=engine_setup(), source_name=SOURCE, server_address=args.gabriel, all_responses_required=True)
+    engine_runner.run(
+        engine=engine_setup(),
+        source_name=SOURCE,
+        server_address=args.gabriel,
+        all_responses_required=True,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -5,18 +5,20 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-import time
 import datetime
 import logging
-from gabriel_server import cognitive_engine
-from gabriel_protocol import gabriel_pb2
-import protocol.common_pb2 as common
-import protocol.gabriel_extras_pb2 as gabriel_extras
-import redis
 import os
-from PIL import Image
+import time
+
 import cv2
 import numpy as np
+import redis
+from gabriel_protocol import gabriel_pb2
+from gabriel_server import cognitive_engine
+from PIL import Image
+
+import protocol.common_pb2 as common
+import protocol.gabriel_extras_pb2 as gabriel_extras
 
 logger = logging.getLogger(__name__)
 log_level = os.getenv('LOG_LEVEL', 'INFO').upper()

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -21,8 +21,9 @@ import protocol.common_pb2 as common
 import protocol.gabriel_extras_pb2 as gabriel_extras
 
 logger = logging.getLogger(__name__)
-log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logger.setLevel(getattr(logging, log_level, logging.INFO))
+
 
 class TelemetryEngine(cognitive_engine.Engine):
     ENGINE_NAME = "telemetry"
@@ -32,8 +33,12 @@ class TelemetryEngine(cognitive_engine.Engine):
 
         # Connect to Redis database
         self.r = redis.Redis(
-            host='redis', port=args.redis, username='steeleagle',
-            password=f'{args.auth}', decode_responses=True)
+            host="redis",
+            port=args.redis,
+            username="steeleagle",
+            password=f"{args.auth}",
+            decode_responses=True,
+        )
         self.r.ping()
         logger.info(f"Connected to redis on port {args.redis}...")
 
@@ -63,7 +68,9 @@ class TelemetryEngine(cognitive_engine.Engine):
                 "rel_altitude": rel_pos.up,
                 "bearing": int(global_pos.heading),
                 "battery": telemetry.battery,
-                "mag": common.MagnetometerWarning.Name(telemetry.alerts.magnetometer_warning),
+                "mag": common.MagnetometerWarning.Name(
+                    telemetry.alerts.magnetometer_warning
+                ),
                 "sats": telemetry.satellites,
                 # Relative Pos (ENU)
                 "enu_east": rel_pos.east,
@@ -71,13 +78,26 @@ class TelemetryEngine(cognitive_engine.Engine):
                 "enu_up": rel_pos.up,
                 "enu_angle": rel_pos.angle,
                 # Velocity Body
-                "v_body_total": np.sqrt(np.sum(np.power([body_vel.forward_vel, body_vel.right_vel, body_vel.up_vel], 2))),
+                "v_body_total": np.sqrt(
+                    np.sum(
+                        np.power(
+                            [body_vel.forward_vel, body_vel.right_vel, body_vel.up_vel],
+                            2,
+                        )
+                    )
+                ),
                 "v_body_forward": body_vel.forward_vel,
                 "v_body_lateral": body_vel.right_vel,
                 "v_body_altitude": body_vel.up_vel,
                 "v_body_angular": body_vel.angular_vel,
                 # Velocity ENU
-                "v_enu_total": np.sqrt(np.sum(np.power([enu_vel.north_vel, enu_vel.east_vel, enu_vel.up_vel], 2))),
+                "v_enu_total": np.sqrt(
+                    np.sum(
+                        np.power(
+                            [enu_vel.north_vel, enu_vel.east_vel, enu_vel.up_vel], 2
+                        )
+                    )
+                ),
                 "v_enu_north": enu_vel.north_vel,
                 "v_enu_east": enu_vel.east_vel,
                 "v_enu_up": enu_vel.up_vel,
@@ -85,11 +105,13 @@ class TelemetryEngine(cognitive_engine.Engine):
                 # Gimbal Pose
                 "gimbal_pitch": gimb_pose.pitch,
                 "gimbal_roll": gimb_pose.roll,
-                "gimbal_yaw": gimb_pose.yaw
+                "gimbal_yaw": gimb_pose.yaw,
             },
         )
         self.r.expire(f"telemetry:{telemetry.drone_name}", 60 * 60 * 24)
-        logger.debug(f"Updated status of {telemetry.drone_name} in redis under stream telemetry at key {key}")
+        logger.debug(
+            f"Updated status of {telemetry.drone_name} in redis under stream telemetry at key {key}"
+        )
 
         drone_key = f"drone:{telemetry.drone_name}"
         self.r.hset(drone_key, "last_seen", f"{time.time()}")
@@ -105,14 +127,36 @@ class TelemetryEngine(cognitive_engine.Engine):
         self.r.hset(drone_key, "home_long", f"{telemetry.home.longitude}")
         self.r.hset(drone_key, "home_alt", f"{telemetry.home.altitude}")
         # Camera Information
-        self.r.hset(drone_key, "streams_allowed", f"{telemetry.cameras.stream_status.total_streams}")
-        self.r.hset(drone_key, "streams_active", f"{telemetry.cameras.stream_status.num_streams}")
-        self.r.hset(drone_key, "primary_cam_id", f"{telemetry.cameras.stream_status.primary_cam}")
+        self.r.hset(
+            drone_key,
+            "streams_allowed",
+            f"{telemetry.cameras.stream_status.total_streams}",
+        )
+        self.r.hset(
+            drone_key,
+            "streams_active",
+            f"{telemetry.cameras.stream_status.num_streams}",
+        )
+        self.r.hset(
+            drone_key,
+            "primary_cam_id",
+            f"{telemetry.cameras.stream_status.primary_cam}",
+        )
         for i in range(len(telemetry.cameras.stream_status.secondary_cams)):
             self.r.hset(drone_key, f"cam_{i}_id", f"{telemetry.cameras.sensors[i].id}")
-            self.r.hset(drone_key, f"cam_{i}_type", f"{common.ImagingSensorType.Name(telemetry.cameras.sensors[i].type)}")
-            self.r.hset(drone_key, f"cam_{i}_active", f"{telemetry.cameras.sensors[i].active}")
-            self.r.hset(drone_key, f"cam_{i}_support_sec", f"{telemetry.cameras.sensors[i].supports_secondary}")
+            self.r.hset(
+                drone_key,
+                f"cam_{i}_type",
+                f"{common.ImagingSensorType.Name(telemetry.cameras.sensors[i].type)}",
+            )
+            self.r.hset(
+                drone_key, f"cam_{i}_active", f"{telemetry.cameras.sensors[i].active}"
+            )
+            self.r.hset(
+                drone_key,
+                f"cam_{i}_support_sec",
+                f"{telemetry.cameras.sensors[i].supports_secondary}",
+            )
 
         self.r.expire(drone_key, self.ttl_secs)
         logger.debug(f"Updating {drone_key} status: last_seen: {time.time()}")
@@ -135,11 +179,15 @@ class TelemetryEngine(cognitive_engine.Engine):
 
         elif input_frame.payload_type == gabriel_pb2.PayloadType.IMAGE:
             image_np = np.fromstring(input_frame.payloads[0], dtype=np.uint8)
-            #have redis publish the latest image
+            # have redis publish the latest image
             if self.publish:
-                logger.info(f"Publishing image to redis under imagery.{extras.telemetry.drone_name} topic.")
-                self.r.publish(f'imagery.{extras.telemetry.drone_name}', input_frame.payloads[0])
-            #store images in the shared volume
+                logger.info(
+                    f"Publishing image to redis under imagery.{extras.telemetry.drone_name} topic."
+                )
+                self.r.publish(
+                    f"imagery.{extras.telemetry.drone_name}", input_frame.payloads[0]
+                )
+            # store images in the shared volume
             try:
                 img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
@@ -153,8 +201,12 @@ class TelemetryEngine(cognitive_engine.Engine):
                 try:
                     os.mkdir(current_path)
                 except FileExistsError:
-                    logger.debug(f"Directory {current_path} already exists. Moving on...")
-                img.save(f"{current_path}/{now.strftime('%H%M.%S%f')}.jpg", format="JPEG")
+                    logger.debug(
+                        f"Directory {current_path} already exists. Moving on..."
+                    )
+                img.save(
+                    f"{current_path}/{now.strftime('%H%M.%S%f')}.jpg", format="JPEG"
+                )
 
                 drone_raw_dir = f"{self.storage_path}/raw/{extras.telemetry.drone_name}"
                 img.save(f"{drone_raw_dir}/temp.jpg", format="JPEG")
@@ -169,4 +221,3 @@ class TelemetryEngine(cognitive_engine.Engine):
         if result is not None:
             result_wrapper.results.append(result)
         return result_wrapper
-

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -86,6 +86,7 @@ class TelemetryEngine(cognitive_engine.Engine):
                 "gimbal_yaw": gimb_pose.yaw
             },
         )
+        self.r.expire(f"telemetry:{telemetry.drone_name}", 60 * 60 * 24)
         logger.debug(f"Updated status of {telemetry.drone_name} in redis under stream telemetry at key {key}")
 
         drone_key = f"drone:{telemetry.drone_name}"

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -57,8 +57,8 @@ class TelemetryEngine(cognitive_engine.Engine):
             {
                 "latitude": global_pos.latitude,
                 "longitude": global_pos.longitude,
-                "abs_altitude": global_pos.absolute_altitude,
-                "rel_altitude": global_pos.relative_altitude,
+                "abs_altitude": global_pos.altitude,
+                "rel_altitude": rel_pos.up,
                 "bearing": int(global_pos.heading),
                 "battery": telemetry.battery,
                 "mag": common.MagnetometerWarning.Name(telemetry.alerts.magnetometer_warning),

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -47,7 +47,7 @@ class TelemetryEngine(cognitive_engine.Engine):
             os.makedirs(self.storage_path + "/raw")
         except FileExistsError:
             logger.info("Images directory already exists.")
-        logger.info("Storing detection images at {}".format(self.storage_path))
+        logger.info(f"Storing detection images at {self.storage_path}")
 
         self.publish = args.publish
         self.ttl_secs = args.ttl * 24 * 3600
@@ -174,7 +174,7 @@ class TelemetryEngine(cognitive_engine.Engine):
             if extras.telemetry.drone_name != "":
                 result = gabriel_pb2.ResultWrapper.Result()
                 result.payload_type = gabriel_pb2.PayloadType.TEXT
-                result.payload = "Telemetry updated.".encode(encoding="utf-8")
+                result.payload = b"Telemetry updated."
                 self.updateDroneStatus(extras)
 
         elif input_frame.payload_type == gabriel_pb2.PayloadType.IMAGE:

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -158,7 +158,7 @@ class TelemetryEngine(cognitive_engine.Engine):
                 img.save(f"{drone_raw_dir}/temp.jpg", format="JPEG")
                 os.rename(f"{drone_raw_dir}/temp.jpg", f"{drone_raw_dir}/latest.jpg")
 
-                logger.info(f"Updated latest image for {extras.telemetry.drone_name}")
+                logger.debug(f"Updated latest image for {extras.telemetry.drone_name}")
             except Exception as e:
                 logger.error(f"Exception trying to store imagery: {e}")
 

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -100,7 +100,7 @@ class TelemetryEngine(cognitive_engine.Engine):
         # Home Location
         self.r.hset(drone_key, "home_lat", f"{telemetry.home.latitude}")
         self.r.hset(drone_key, "home_long", f"{telemetry.home.longitude}")
-        self.r.hset(drone_key, "home_alt", f"{telemetry.home.absolute_altitude}")
+        self.r.hset(drone_key, "home_alt", f"{telemetry.home.altitude}")
         # Camera Information
         self.r.hset(drone_key, "streams_allowed", f"{telemetry.cameras.stream_status.total_streams}")
         self.r.hset(drone_key, "streams_active", f"{telemetry.cameras.stream_status.num_streams}")

--- a/backend/server/engines/telemetry/telemetry_engine.py
+++ b/backend/server/engines/telemetry/telemetry_engine.py
@@ -150,7 +150,7 @@ class TelemetryEngine(cognitive_engine.Engine):
                 try:
                     os.mkdir(current_path)
                 except FileExistsError:
-                    logger.error(f"Directory {current_path} already exists. Moving on...")
+                    logger.debug(f"Directory {current_path} already exists. Moving on...")
                 img.save(f"{current_path}/{now.strftime('%H%M.%S%f')}.jpg", format="JPEG")
 
                 drone_raw_dir = f"{self.storage_path}/raw/{extras.telemetry.drone_name}"

--- a/backend/server/test/compiler_test.py
+++ b/backend/server/test/compiler_test.py
@@ -1,9 +1,11 @@
 import os
 import subprocess
 
-compiler_path =  '/compiler'
-output_path = '/compiler/out/flightplan_'
-platform_path = '/compiler/python'
+compiler_path = "/compiler"
+output_path = "/compiler/out/flightplan_"
+platform_path = "/compiler/python"
+
+
 def compile_mission(dsl_file, kml_file, drone_list):
     # Construct the full paths for the DSL and KML files
     dsl_file_path = os.path.join(compiler_path, dsl_file)
@@ -13,28 +15,34 @@ def compile_mission(dsl_file, kml_file, drone_list):
     # Define the command and arguments
     command = [
         "java",
-        "-jar", jar_path,
-        "-d", drone_list,
-        "-s", dsl_file_path,
-        "-k", kml_file_path,
-        "-o", output_path,
-        "-p", platform_path
+        "-jar",
+        jar_path,
+        "-d",
+        drone_list,
+        "-s",
+        dsl_file_path,
+        "-k",
+        kml_file_path,
+        "-o",
+        output_path,
+        "-p",
+        platform_path,
     ]
-    
+
     try:
         # Run the command
-        result =  subprocess.run(command, check=True, capture_output=True, text=True)
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
         print("output: ", result)
 
         # Output the results
         print("Compilation successful.")
-    
+
     except subprocess.CalledProcessError as e:
         print("Error output:", e.stderr)
 
 
-if __name__ == '__main__':
-    kml_file = 'tst.kml'
-    dsl_file = 'tst.dsl'
-    drone_list = 'ant&mamba'
+if __name__ == "__main__":
+    kml_file = "tst.kml"
+    dsl_file = "tst.dsl"
+    drone_list = "ant&mamba"
     compile_mission(dsl_file, kml_file, drone_list)

--- a/backend/server/test/streaming_test_socket.py
+++ b/backend/server/test/streaming_test_socket.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
+import argparse
 import socket
+import time
+
 import cv2
 import numpy as np
-import time
 import zmq
-import argparse
 
 HOST=''
 PORT=8485

--- a/backend/server/test/streaming_test_socket.py
+++ b/backend/server/test/streaming_test_socket.py
@@ -102,7 +102,7 @@ def _main():
 
                 now = time.time()
                 if now - lastprint > 5:
-                    print("avg fps: {0:.2f}".format((frames_received - lastcount) / 5))
+                    print(f"avg fps: {(frames_received - lastcount) / 5:.2f}")
                     print()
                     lastcount = frames_received
                     lastprint = now

--- a/backend/server/test/streaming_test_socket.py
+++ b/backend/server/test/streaming_test_socket.py
@@ -8,7 +8,6 @@ import numpy as np
 import time
 import zmq
 import argparse
-import sys
 
 HOST=''
 PORT=8485

--- a/backend/server/test/streaming_test_socket.py
+++ b/backend/server/test/streaming_test_socket.py
@@ -10,56 +10,66 @@ import cv2
 import numpy as np
 import zmq
 
-HOST=''
-PORT=8485
-LOC = {'latitude': 40.4136589, 'longitude': -79.9495332, 'altitude': 10}
+HOST = ""
+PORT = 8485
+LOC = {"latitude": 40.4136589, "longitude": -79.9495332, "altitude": 10}
+
 
 # Required for sending image over zmq
 def send_array(sock, A, flags=0, copy=True, track=False):
     """send a numpy array with metadata"""
     global LOC
-    md = dict(
-        dtype = str(A.dtype),
-        shape = A.shape,
-        location = LOC,
-        model = 'robomaster'
-    )
-    sock.send_json(md, flags|zmq.SNDMORE)
+    md = dict(dtype=str(A.dtype), shape=A.shape, location=LOC, model="robomaster")
+    sock.send_json(md, flags | zmq.SNDMORE)
     return sock.send(A, flags, copy=copy, track=track)
 
 
 def recv_from_nonblocking(fd: socket, size: int) -> bytes:
-  buf, received = [], 0
-  while received < size:
-    buf.append(fd.recv(size - received))
-    received += len(buf[-1])
-  return b"".join(buf)
+    buf, received = [], 0
+    while received < size:
+        buf.append(fd.recv(size - received))
+        received += len(buf[-1])
+    return b"".join(buf)
+
 
 def _main():
-
-    parser = argparse.ArgumentParser(prog='test_socket', 
-        description='Receives image frames from Android streaming test app.')
-    parser.add_argument('-p', '--port', default=8485,
-        help='Specify port to listen on [default: 8485]')
-    parser.add_argument('-zp', '--zmq_port', default=5555,
-        help='Specify zmq port to publish to [default: 5555]')
-    parser.add_argument('-s', '--store', action='store_true', 
-        help='Store images locally on disk [default: False]')
-    parser.add_argument('-z', '--zmq', action='store_true', 
-        help='Send images over zmq to OpenScout (assumes OpenScout is listening locally) [default: False]')
-    parser.add_argument('-d', '--direct_send', action='store_true')
+    parser = argparse.ArgumentParser(
+        prog="test_socket",
+        description="Receives image frames from Android streaming test app.",
+    )
+    parser.add_argument(
+        "-p", "--port", default=8485, help="Specify port to listen on [default: 8485]"
+    )
+    parser.add_argument(
+        "-zp",
+        "--zmq_port",
+        default=5555,
+        help="Specify zmq port to publish to [default: 5555]",
+    )
+    parser.add_argument(
+        "-s",
+        "--store",
+        action="store_true",
+        help="Store images locally on disk [default: False]",
+    )
+    parser.add_argument(
+        "-z",
+        "--zmq",
+        action="store_true",
+        help="Send images over zmq to OpenScout (assumes OpenScout is listening locally) [default: False]",
+    )
+    parser.add_argument("-d", "--direct_send", action="store_true")
 
     args = parser.parse_args()
 
-
-    s=socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind((HOST,args.port))
-    print(f'Socket bound to port: {args.port}')
+    s.bind((HOST, args.port))
+    print(f"Socket bound to port: {args.port}")
     s.listen(10)
-    print('Socket now listening...')
+    print("Socket now listening...")
 
-    conn,addr=s.accept()
+    conn, addr = s.accept()
     data = b""
     if args.zmq:
         context = zmq.Context()
@@ -68,10 +78,12 @@ def _main():
 
     try:
         with conn:
-            if(args.zmq):
-                print(f"Publishing images for OpenScout client's ZmqAdapter on port {args.zmq_port}..")
+            if args.zmq:
+                print(
+                    f"Publishing images for OpenScout client's ZmqAdapter on port {args.zmq_port}.."
+                )
                 zmq_socket = context.socket(zmq.PUB)
-                zmq_socket.bind(f'tcp://*:{args.zmq_port}')
+                zmq_socket.bind(f"tcp://*:{args.zmq_port}")
 
             print(f"Client connected {addr}")
             frames_received = 0
@@ -82,42 +94,42 @@ def _main():
                 start = time.time()
                 header = recv_from_nonblocking(conn, 4)
                 size = int.from_bytes(header, "big")
-                #print(f"About to receive an image of {size} bytes...")
+                # print(f"About to receive an image of {size} bytes...")
                 data = recv_from_nonblocking(conn, size)
                 frames_received += 1
-                #print(f"Frames Received: {frames_received} Data Length: {len(data)}")
+                # print(f"Frames Received: {frames_received} Data Length: {len(data)}")
 
                 now = time.time()
                 if now - lastprint > 5:
-                    print(
-                        "avg fps: {0:.2f}".format(
-                            (frames_received - lastcount) / 5)
-                        )
+                    print("avg fps: {0:.2f}".format((frames_received - lastcount) / 5))
                     print()
                     lastcount = frames_received
                     lastprint = now
 
                 if not args.direct_send:
-                    frame = cv2.imdecode(np.fromstring(data, np.uint8), cv2.IMREAD_COLOR)
-                    #cv2frame = cv2.cvtColor(frame.as_ndarray(), cv2.COLOR_YUV2BGR_I420)
+                    frame = cv2.imdecode(
+                        np.fromstring(data, np.uint8), cv2.IMREAD_COLOR
+                    )
+                    # cv2frame = cv2.cvtColor(frame.as_ndarray(), cv2.COLOR_YUV2BGR_I420)
                 else:
                     packets = codec.parse(data)
                     for packet in packets:
                         frames = codec.decode(packet)
                         frame = frames[-1]
 
-                if(args.zmq):
+                if args.zmq:
                     print(f"Publishing frame {frames_received} to OpenScout client...")
                     send_array(zmq_socket, frame)
 
-                if(args.store):
-                    cv2.imwrite(f'{frames_received}.jpg', frame)
-                cv2.imshow('server',frame)
+                if args.store:
+                    cv2.imwrite(f"{frames_received}.jpg", frame)
+                cv2.imshow("server", frame)
                 cv2.waitKey(1)
 
     except KeyboardInterrupt:
         s.close()
-        print('Socket closed')
+        print("Socket closed")
+
 
 if __name__ == "__main__":
     _main()

--- a/backend/server/test/streaming_test_socket.py
+++ b/backend/server/test/streaming_test_socket.py
@@ -6,6 +6,7 @@ import argparse
 import socket
 import time
 
+import av
 import cv2
 import numpy as np
 import zmq

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -85,11 +85,13 @@
       <div class="md-grid md-typeset">
         <h1 class="feature-header hidden">Modules</h1>
         <div class="feature-grid">
-          <div class="feature-card hidden">
-            <div class="feature-icon">🤖</div>
-            <h3>Companion</h3>
-            <p>Framework for adding new robots, modifying local compute, and supporting disconnected operation.</p>
-          </div>
+          <a href="{{ 'platforms/companions' | url }}">
+            <div class="feature-card hidden">
+              <div class="feature-icon">🤖</div>
+              <h3>Companion</h3>
+              <p>Framework for adding new robots, modifying local compute, and supporting disconnected operation.</p>
+            </div>
+          </a>
           <div class="feature-card hidden">
             <div class="feature-icon">🗃️</div>
             <h3>Backend</h3>

--- a/docs/platforms/companions.md
+++ b/docs/platforms/companions.md
@@ -1,0 +1,1 @@
+## Onion Omega LTE

--- a/docs/platforms/uavs.md
+++ b/docs/platforms/uavs.md
@@ -1,0 +1,13 @@
+## Parrot
+
+### ANAFI
+
+### ANAFI USA/GOV
+
+## Modal AI
+
+### Starling 2 MAX
+
+## Sky Rocket
+
+### Sky Viper V2450GPS

--- a/gcs/dearpygui/commander.py
+++ b/gcs/dearpygui/commander.py
@@ -1,12 +1,12 @@
-import dearpygui.dearpygui as dpg
-
-import yaml
-import redis
-import zmq
+import os
+import random
 import time
 import webbrowser
-import random
-import os
+
+import dearpygui.dearpygui as dpg
+import redis
+import yaml
+import zmq
 
 #TODO: Get these from redis
 TYPES = ["ANAFI", "ANAFI USA", "ANAFI Ai", "ModalAi Seeker", "ModalAi Starling"]

--- a/gcs/dearpygui/commander.py
+++ b/gcs/dearpygui/commander.py
@@ -1,9 +1,7 @@
 import dearpygui.dearpygui as dpg
-import dearpygui_extend as dpge
 
 import yaml
 import redis
-import pandas as pd
 import zmq
 import time
 import webbrowser
@@ -145,13 +143,13 @@ def update_dronelist():
 def update_imagery():
     if dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == "detection_tab":
         width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/detected/latest.jpg")
-        dpg.set_value(f"texture_detection", data)
+        dpg.set_value("texture_detection", data)
     elif dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == "avoidance_tab":
         width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/moa/latest.jpg")
-        dpg.set_value(f"texture_moa", data)
+        dpg.set_value("texture_moa", data)
     elif dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == "hsv_tab":
         width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/detected/hsv.jpg")
-        dpg.set_value(f"texture_hsv", data)
+        dpg.set_value("texture_hsv", data)
     else:
         for d in get_drones():
             if dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == f"{d}_tab":
@@ -164,10 +162,10 @@ def update_imagery():
 def arm_disarm(sender, app_data, user_data):
     _log_interaction(sender, app_data, user_data)
     if app_data:
-        dpg.set_value("manual_control_label", f"Manual Control Enabled")
+        dpg.set_value("manual_control_label", "Manual Control Enabled")
         dpg.configure_item("manual_control_label", color=(0,255,0))
     else:
-        dpg.set_value("manual_control_label", f"Manual Control Disabled")
+        dpg.set_value("manual_control_label", "Manual Control Disabled")
         dpg.configure_item("manual_control_label", color=(255,0,0))
 
 

--- a/gcs/dearpygui/commander.py
+++ b/gcs/dearpygui/commander.py
@@ -8,23 +8,25 @@ import redis
 import yaml
 import zmq
 
-#TODO: Get these from redis
+# TODO: Get these from redis
 TYPES = ["ANAFI", "ANAFI USA", "ANAFI Ai", "ModalAi Seeker", "ModalAi Starling"]
 STATUSES = ["offline", "idle", "TrackingTask", "PatrolTask"]
-STATUS_COLORS = [(255,0,0), (0,255,255), (200,0,200), (200,0,200)]
+STATUS_COLORS = [(255, 0, 0), (0, 255, 255), (200, 0, 200), (200, 0, 200)]
 
-with open('config.yaml', 'r') as conf:
+with open("config.yaml", "r") as conf:
     SECRETS = yaml.safe_load(conf)
+
 
 def connect_redis():
     red = redis.Redis(
-        host=SECRETS['redis']['host'],
-        port=SECRETS['redis']['port'],
-        username=SECRETS['redis']['user'],
-        password=SECRETS['redis']['pass'],
+        host=SECRETS["redis"]["host"],
+        port=SECRETS["redis"]["port"],
+        username=SECRETS["redis"]["user"],
+        password=SECRETS["redis"]["pass"],
         decode_responses=True,
     )
     return red
+
 
 def connect_zmq():
     ctx = zmq.Context()
@@ -38,15 +40,20 @@ def get_drones(threshold=999999):
     red = connect_redis()
     for k in red.keys("telemetry.*"):
         latest_entry = red.xrevrange(f"{k}", "+", "-", 1)
-        last_update = (int(latest_entry[0][0].split("-")[0])/1000)
-        if time.time() - last_update <  threshold * 60: # minutes -> seconds
-            l[f"{k.split('.')[-1]}"] = f"**{k.split('.')[-1]}** " 
+        last_update = int(latest_entry[0][0].split("-")[0]) / 1000
+        if time.time() - last_update < threshold * 60:  # minutes -> seconds
+            l[f"{k.split('.')[-1]}"] = f"**{k.split('.')[-1]}** "
 
     return sorted(l)
 
+
 def _log_interaction(sender, app_data, user_data):
     current = dpg.get_value("status_bar_text")
-    dpg.set_value("status_bar_text", f"sender: {sender}\tapp_data: {app_data}\tuser_data: {user_data}\n{current}")
+    dpg.set_value(
+        "status_bar_text",
+        f"sender: {sender}\tapp_data: {app_data}\tuser_data: {user_data}\n{current}",
+    )
+
 
 def _log(arbitrary):
     current = dpg.get_value("status_bar_text")
@@ -56,15 +63,17 @@ def _log(arbitrary):
 def _select_all(sender, app_data, user_data):
     selections.clear()
     for item in dronelist:
-        selections.append(f'{item}_selectable')
-        dpg.set_value(f'{item}_selectable', True)
+        selections.append(f"{item}_selectable")
+        dpg.set_value(f"{item}_selectable", True)
     _log_interaction(sender, app_data, selections)
+
 
 def _select_none(sender, app_data, user_data):
     selections.clear()
     for item in dronelist:
-        dpg.set_value(f'{item}_selectable', False)
+        dpg.set_value(f"{item}_selectable", False)
     _log_interaction(sender, app_data, selections)
+
 
 def _selection(sender, app_data, user_data):
     if sender not in selections:
@@ -73,36 +82,57 @@ def _selection(sender, app_data, user_data):
     else:
         selections.remove(sender)
         dpg.set_value(sender, False)
-    print(f'Sender: {sender}  Currrent Selection:{selections}')
+    print(f"Sender: {sender}  Currrent Selection:{selections}")
     _log_interaction(sender, app_data, selections)
 
-def _hyperlink(text, address):
-    b = dpg.add_button(label=text, callback=lambda:webbrowser.open(address))
 
-def _add_card(label='Card', model="ANAFI", status="offline", tag_prefix="Card"):
-    with dpg.table(tag=f'{tag_prefix}_table', row_background=False, resizable=False, header_row=False, borders_innerH=True,  borders_outerH=True, borders_innerV=True, borders_outerV=True):
-        dpg.add_table_column(no_resize=True, init_width_or_weight=0.25)            
+def _hyperlink(text, address):
+    b = dpg.add_button(label=text, callback=lambda: webbrowser.open(address))
+
+
+def _add_card(label="Card", model="ANAFI", status="offline", tag_prefix="Card"):
+    with dpg.table(
+        tag=f"{tag_prefix}_table",
+        row_background=False,
+        resizable=False,
+        header_row=False,
+        borders_innerH=True,
+        borders_outerH=True,
+        borders_innerV=True,
+        borders_outerV=True,
+    ):
+        dpg.add_table_column(no_resize=True, init_width_or_weight=0.25)
         dpg.add_table_column()
 
         with dpg.table_row():
-            dpg.add_checkbox(tag=f'{tag_prefix}_selectable', indent=4)
-            dpg.configure_item(f'{tag_prefix}_selectable', callback=_selection, user_data=selections)
-            dpg.add_text(f'{label}', )
+            dpg.add_checkbox(tag=f"{tag_prefix}_selectable", indent=4)
+            dpg.configure_item(
+                f"{tag_prefix}_selectable", callback=_selection, user_data=selections
+            )
+            dpg.add_text(
+                f"{label}",
+            )
             dpg.add_table_cell()
 
         with dpg.table_row():
-            #dpg.add_table_cell()
-            dpg.add_text('Model')
-            dpg.add_text(f'{model}')
+            # dpg.add_table_cell()
+            dpg.add_text("Model")
+            dpg.add_text(f"{model}")
 
         with dpg.table_row():
-            #dpg.add_table_cell()
-            dpg.add_text('Batt')
-            dpg.add_text(f'{random.randint(0,100)}%',)
+            # dpg.add_table_cell()
+            dpg.add_text("Batt")
+            dpg.add_text(
+                f"{random.randint(0, 100)}%",
+            )
 
         with dpg.table_row():
-            dpg.add_text('Status')
-            dpg.add_text(STATUSES[status], color=STATUS_COLORS[status],)
+            dpg.add_text("Status")
+            dpg.add_text(
+                STATUSES[status],
+                color=STATUS_COLORS[status],
+            )
+
 
 def _help(message):
     last_item = dpg.last_item()
@@ -113,10 +143,11 @@ def _help(message):
     with dpg.tooltip(t):
         dpg.add_text(message)
 
+
 def _key_handler(sender, data):
     print(f"sender: {sender} data: {data}")
-    type=dpg.get_item_info(sender)["type"]
-    if type=="mvAppItemType::mvKeyDownHandler":
+    type = dpg.get_item_info(sender)["type"]
+    if type == "mvAppItemType::mvKeyDownHandler":
         match data[0]:
             case 68:
                 vel = dpg.get_value("roll_slider")
@@ -133,40 +164,57 @@ def _key_handler(sender, data):
             case _:
                 _log(f"Key pressed: {data}")
 
+
 def update_dronelist():
     dronelist = get_drones(dpg.get_value("active_slider"))
-    dpg.delete_item(item='dronelist_group', children_only=True, )
+    dpg.delete_item(
+        item="dronelist_group",
+        children_only=True,
+    )
     for item in dronelist:
-        dpg.add_selectable(parent='dronelist_group', label=item, tag=f'{item}_selectable', indent=10)
-        dpg.configure_item(f'{item}_selectable', callback=_selection, user_data=selections)
+        dpg.add_selectable(
+            parent="dronelist_group", label=item, tag=f"{item}_selectable", indent=10
+        )
+        dpg.configure_item(
+            f"{item}_selectable", callback=_selection, user_data=selections
+        )
+
 
 def update_imagery():
     if dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == "detection_tab":
-        width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/detected/latest.jpg")
+        width, height, channels, data = dpg.load_image(
+            f"{SECRETS['image_vol']}/detected/latest.jpg"
+        )
         dpg.set_value("texture_detection", data)
     elif dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == "avoidance_tab":
-        width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/moa/latest.jpg")
+        width, height, channels, data = dpg.load_image(
+            f"{SECRETS['image_vol']}/moa/latest.jpg"
+        )
         dpg.set_value("texture_moa", data)
     elif dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == "hsv_tab":
-        width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/detected/hsv.jpg")
+        width, height, channels, data = dpg.load_image(
+            f"{SECRETS['image_vol']}/detected/hsv.jpg"
+        )
         dpg.set_value("texture_hsv", data)
     else:
         for d in get_drones():
             if dpg.get_item_alias(dpg.get_value("imagery_tabbar")) == f"{d}_tab":
-                width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/raw/{d}/latest.jpg")
+                width, height, channels, data = dpg.load_image(
+                    f"{SECRETS['image_vol']}/raw/{d}/latest.jpg"
+                )
                 dpg.set_value(f"texture_{d}", data)
-                #dpg.configure_item(f"texture_{d}", width=width, height=height, default_value=data)
-                #dpg.configure_item(f"latest_{d}", texture_tag=f"texture_{d}")
+                # dpg.configure_item(f"texture_{d}", width=width, height=height, default_value=data)
+                # dpg.configure_item(f"latest_{d}", texture_tag=f"texture_{d}")
 
 
 def arm_disarm(sender, app_data, user_data):
     _log_interaction(sender, app_data, user_data)
     if app_data:
         dpg.set_value("manual_control_label", "Manual Control Enabled")
-        dpg.configure_item("manual_control_label", color=(0,255,0))
+        dpg.configure_item("manual_control_label", color=(0, 255, 0))
     else:
         dpg.set_value("manual_control_label", "Manual Control Disabled")
-        dpg.configure_item("manual_control_label", color=(255,0,0))
+        dpg.configure_item("manual_control_label", color=(255, 0, 0))
 
 
 def set_mission(sender, app_data, user_data):
@@ -174,43 +222,65 @@ def set_mission(sender, app_data, user_data):
     dpg.set_value("selected_dsl_path", app_data["file_name"])
     dpg.configure_item("selected_dsl_path", color=(235, 128, 52))
 
+
 def set_scope(sender, app_data, user_data):
     _log_interaction(sender, app_data, user_data)
     dpg.set_value("selected_kml_path", app_data["file_name"])
     dpg.configure_item("selected_kml_path", color=(235, 128, 52))
 
+
 def save_init():
-    dpg.save_init_file('dpg.ini')
+    dpg.save_init_file("dpg.ini")
     _log("Saved window positions to dpg.ini.")
+
 
 dronelist = get_drones()
 
 dpg.create_context()
-with dpg.font_registry(tag='font_registry'):
-    for filename in os.listdir('Fonts'):
-        if filename.endswith((".ttf","otf")):
+with dpg.font_registry(tag="font_registry"):
+    for filename in os.listdir("Fonts"):
+        if filename.endswith((".ttf", "otf")):
             font = dpg.add_font(f"Fonts/{filename}", 16)
 dpg.bind_font(font)
 
 
 with dpg.theme(tag="global_theme") as global_theme:
     with dpg.theme_component(dpg.mvAll):
-        dpg.add_theme_color(dpg.mvThemeCol_FrameBg, (12, 12, 12), category=dpg.mvThemeCat_Core)
-        dpg.add_theme_style(dpg.mvStyleVar_FrameRounding, 6, category=dpg.mvThemeCat_Core)
-        dpg.add_theme_style(dpg.mvStyleVar_FrameBorderSize, 1 , category=dpg.mvThemeCat_Core)
-        dpg.add_theme_style(dpg.mvStyleVar_WindowRounding, 10 , category=dpg.mvThemeCat_Core)
-        dpg.add_theme_style(dpg.mvStyleVar_WindowBorderSize, 1 , category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(
+            dpg.mvThemeCol_FrameBg, (12, 12, 12), category=dpg.mvThemeCat_Core
+        )
+        dpg.add_theme_style(
+            dpg.mvStyleVar_FrameRounding, 6, category=dpg.mvThemeCat_Core
+        )
+        dpg.add_theme_style(
+            dpg.mvStyleVar_FrameBorderSize, 1, category=dpg.mvThemeCat_Core
+        )
+        dpg.add_theme_style(
+            dpg.mvStyleVar_WindowRounding, 10, category=dpg.mvThemeCat_Core
+        )
+        dpg.add_theme_style(
+            dpg.mvStyleVar_WindowBorderSize, 1, category=dpg.mvThemeCat_Core
+        )
 dpg.bind_theme(global_theme)
 
-dpg.create_viewport(title='SteelEagle Commander', min_height=720, min_width=1280)
+dpg.create_viewport(title="SteelEagle Commander", min_height=720, min_width=1280)
 
 with dpg.viewport_menu_bar():
     with dpg.menu(label="Preferences"):
-        dpg.add_menu_item(label="Font Registry", callback=lambda:dpg.show_tool(dpg.mvTool_Font))
-        dpg.add_menu_item(label="Style Editor", callback=lambda:dpg.show_tool(dpg.mvTool_Style))
+        dpg.add_menu_item(
+            label="Font Registry", callback=lambda: dpg.show_tool(dpg.mvTool_Font)
+        )
+        dpg.add_menu_item(
+            label="Style Editor", callback=lambda: dpg.show_tool(dpg.mvTool_Style)
+        )
     with dpg.menu(label="Help"):
-        dpg.add_menu_item(label="Show Metrics", callback=lambda:dpg.show_tool(dpg.mvTool_Metrics))
-        dpg.add_menu_item(label="Show Item Registry", callback=lambda:dpg.show_tool(dpg.mvTool_ItemRegistry))
+        dpg.add_menu_item(
+            label="Show Metrics", callback=lambda: dpg.show_tool(dpg.mvTool_Metrics)
+        )
+        dpg.add_menu_item(
+            label="Show Item Registry",
+            callback=lambda: dpg.show_tool(dpg.mvTool_ItemRegistry),
+        )
 
 with dpg.handler_registry(show=True, tag="keyboard_handler"):
     k_press = dpg.add_key_down_handler(key=dpg.mvKey_A, callback=_key_handler)
@@ -220,51 +290,162 @@ with dpg.handler_registry(show=True, tag="keyboard_handler"):
 
 
 selections = []
-with dpg.window(tag='drone_list', label="Available Drones", pos=[400,100], menubar=True, autosize=True, no_close=True, no_resize=True):
+with dpg.window(
+    tag="drone_list",
+    label="Available Drones",
+    pos=[400, 100],
+    menubar=True,
+    autosize=True,
+    no_close=True,
+    no_resize=True,
+):
     with dpg.menu_bar():
         with dpg.menu(label="Selection"):
             dpg.add_menu_item(label="Select All", callback=_select_all)
             dpg.add_menu_item(label="Select None", callback=_select_none)
 
     for item in dronelist:
-        _add_card(label=item, tag_prefix=item, model=random.choice(TYPES), status=random.randint(0,len(STATUSES)-1))
+        _add_card(
+            label=item,
+            tag_prefix=item,
+            model=random.choice(TYPES),
+            status=random.randint(0, len(STATUSES) - 1),
+        )
 
-with dpg.window(tag='control_pane', label="Control Pane", autosize=True, no_close=True, no_resize=True):
+with dpg.window(
+    tag="control_pane",
+    label="Control Pane",
+    autosize=True,
+    no_close=True,
+    no_resize=True,
+):
     dpg.add_checkbox(tag="arm_checkbox", label="Arm Swarm?", callback=arm_disarm)
-    dpg.add_text(tag="manual_control_label", default_value="Manual Control Disabled", color=(255,0,0))
+    dpg.add_text(
+        tag="manual_control_label",
+        default_value="Manual Control Disabled",
+        color=(255, 0, 0),
+    )
     _help("When armed, manual commands can be sent to all selected drones.")
     dpg.add_separator()
     dpg.add_separator()
-    dpg.add_text(tag="autonomous_header", default_value="Autonomous Control", color=(168, 52, 235))
+    dpg.add_text(
+        tag="autonomous_header",
+        default_value="Autonomous Control",
+        color=(168, 52, 235),
+    )
     with dpg.file_dialog(
-        directory_selector=False, modal=True, show=False, callback=set_mission, tag="dsl_dialog",
-        cancel_callback=_log_interaction, width=700 ,height=400):
-            dpg.add_file_extension(".dsl", color=(0, 255, 0, 255))
+        directory_selector=False,
+        modal=True,
+        show=False,
+        callback=set_mission,
+        tag="dsl_dialog",
+        cancel_callback=_log_interaction,
+        width=700,
+        height=400,
+    ):
+        dpg.add_file_extension(".dsl", color=(0, 255, 0, 255))
     with dpg.file_dialog(
-        directory_selector=False, modal=True, show=False, callback=set_scope, tag="kml_dialog",
-        cancel_callback=_log_interaction, width=700 ,height=400):
-            dpg.add_file_extension(".kml", color=(0, 255, 0, 255))
+        directory_selector=False,
+        modal=True,
+        show=False,
+        callback=set_scope,
+        tag="kml_dialog",
+        cancel_callback=_log_interaction,
+        width=700,
+        height=400,
+    ):
+        dpg.add_file_extension(".kml", color=(0, 255, 0, 255))
     dpg.add_text(tag="selected_dsl_path", default_value="No mission selected.")
-    dpg.add_button(label="Select Mission Script...", width=200,callback=lambda: dpg.show_item("dsl_dialog"))
+    dpg.add_button(
+        label="Select Mission Script...",
+        width=200,
+        callback=lambda: dpg.show_item("dsl_dialog"),
+    )
     dpg.add_text(tag="selected_kml_path", default_value="No scope selected.")
-    dpg.add_button(label="Select Scope...", width=200,callback=lambda: dpg.show_item("kml_dialog"))
+    dpg.add_button(
+        label="Select Scope...", width=200, callback=lambda: dpg.show_item("kml_dialog")
+    )
 
     dpg.add_separator()
     dpg.add_spacer(height=50)
-    dpg.add_button(tag="autonomous_button", label="Fly Mission", width=200, callback=_log_interaction)
+    dpg.add_button(
+        tag="autonomous_button",
+        label="Fly Mission",
+        width=200,
+        callback=_log_interaction,
+    )
     _help("Fly the selected drones with the selected mission/scope.")
-    dpg.add_button(tag="halt_button", label="Halt All", width=200, callback=_log_interaction)
+    dpg.add_button(
+        tag="halt_button", label="Halt All", width=200, callback=_log_interaction
+    )
     _help("Instruct selected drones to immediately hover.")
-    dpg.add_button(tag="rth_button", label="Return Home", width=200, callback=_log_interaction)
+    dpg.add_button(
+        tag="rth_button", label="Return Home", width=200, callback=_log_interaction
+    )
     _help("Instruct selected drones to return to their last home location.")
     dpg.add_spacer(height=50)
-    #sliders for manual control
+    # sliders for manual control
     with dpg.group(horizontal=True):
-        dpg.add_slider_int(tag="yaw_slider", default_value=45, vertical=True, min_value=0, max_value=180, clamped=True, format='%.1f\ndeg/s', width=40, height=100, callback=_log_interaction)
-        dpg.add_slider_float(tag="pitch_slider", default_value=1.0, vertical=True, min_value=0.0, max_value=5.0, clamped=True, format='%.1f\nm/s', width=30, height=100, callback=_log_interaction)
-        dpg.add_slider_float(tag="roll_slider", default_value=1.0, vertical=True, min_value=0.0, max_value=5.0, clamped=True, format='%.1f\nm/s', width=30, height=100, callback=_log_interaction)
-        dpg.add_slider_float(tag="thrust_slider", default_value=1.0, vertical=True, min_value=0.0, max_value=5.0, clamped=True, format='%.1f\nm/s', width=30, height=100, callback=_log_interaction)
-        dpg.add_slider_int(tag="gimbal_slider", default_value=45, vertical=True, min_value=0, max_value=180, clamped=True, format='%.1f\ndeg/s', width=40, height=100, callback=_log_interaction)
+        dpg.add_slider_int(
+            tag="yaw_slider",
+            default_value=45,
+            vertical=True,
+            min_value=0,
+            max_value=180,
+            clamped=True,
+            format="%.1f\ndeg/s",
+            width=40,
+            height=100,
+            callback=_log_interaction,
+        )
+        dpg.add_slider_float(
+            tag="pitch_slider",
+            default_value=1.0,
+            vertical=True,
+            min_value=0.0,
+            max_value=5.0,
+            clamped=True,
+            format="%.1f\nm/s",
+            width=30,
+            height=100,
+            callback=_log_interaction,
+        )
+        dpg.add_slider_float(
+            tag="roll_slider",
+            default_value=1.0,
+            vertical=True,
+            min_value=0.0,
+            max_value=5.0,
+            clamped=True,
+            format="%.1f\nm/s",
+            width=30,
+            height=100,
+            callback=_log_interaction,
+        )
+        dpg.add_slider_float(
+            tag="thrust_slider",
+            default_value=1.0,
+            vertical=True,
+            min_value=0.0,
+            max_value=5.0,
+            clamped=True,
+            format="%.1f\nm/s",
+            width=30,
+            height=100,
+            callback=_log_interaction,
+        )
+        dpg.add_slider_int(
+            tag="gimbal_slider",
+            default_value=45,
+            vertical=True,
+            min_value=0,
+            max_value=180,
+            clamped=True,
+            format="%.1f\ndeg/s",
+            width=40,
+            height=100,
+            callback=_log_interaction,
+        )
     with dpg.group(horizontal=True):
         dpg.add_text("Yaw")
         dpg.add_text("Pitch")
@@ -272,32 +453,63 @@ with dpg.window(tag='control_pane', label="Control Pane", autosize=True, no_clos
         dpg.add_text("Thrust")
         dpg.add_text("Gimbal")
 
-with dpg.window(tag='main_window', autosize=True, no_resize=True, on_close=save_init):
+with dpg.window(tag="main_window", autosize=True, no_resize=True, on_close=save_init):
     dpg.add_spacer(height=20)
     # load initial images into texture registry
     with dpg.texture_registry(show=False):
-        width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/detected/latest.jpg")
-        dpg.add_raw_texture(width=width, height=height, default_value=data, tag="texture_detection")
-        width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/moa/latest.jpg")
-        dpg.add_raw_texture(width=width, height=height, default_value=data, tag="texture_moa")
-        width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/detected/hsv.jpg")
-        dpg.add_raw_texture(width=width, height=height, default_value=data, tag="texture_hsv")
+        width, height, channels, data = dpg.load_image(
+            f"{SECRETS['image_vol']}/detected/latest.jpg"
+        )
+        dpg.add_raw_texture(
+            width=width, height=height, default_value=data, tag="texture_detection"
+        )
+        width, height, channels, data = dpg.load_image(
+            f"{SECRETS['image_vol']}/moa/latest.jpg"
+        )
+        dpg.add_raw_texture(
+            width=width, height=height, default_value=data, tag="texture_moa"
+        )
+        width, height, channels, data = dpg.load_image(
+            f"{SECRETS['image_vol']}/detected/hsv.jpg"
+        )
+        dpg.add_raw_texture(
+            width=width, height=height, default_value=data, tag="texture_hsv"
+        )
         for d in get_drones():
-            width, height, channels, data = dpg.load_image(f"{SECRETS['image_vol']}/raw/{d}/latest.jpg")
-            dpg.add_raw_texture(width=width, height=height, default_value=data, tag=f"texture_{d}")
+            width, height, channels, data = dpg.load_image(
+                f"{SECRETS['image_vol']}/raw/{d}/latest.jpg"
+            )
+            dpg.add_raw_texture(
+                width=width, height=height, default_value=data, tag=f"texture_{d}"
+            )
 
     with dpg.tab_bar(tag="page_tabbar"):
         with dpg.tab(tag="overview_tab", label="Live Imagery"):
             with dpg.tab_bar(tag="imagery_tabbar"):
                 for d in get_drones():
                     with dpg.tab(tag=f"{d}_tab", label=f"{d}"):
-                        dpg.add_image(tag=f"latest_{d}", texture_tag=f"texture_{d}")  
+                        dpg.add_image(tag=f"latest_{d}", texture_tag=f"texture_{d}")
                 with dpg.tab(tag="detection_tab", label="Object Dection"):
-                    dpg.add_image(tag="latest_detection", texture_tag="texture_detection", width=1280, height=720)
+                    dpg.add_image(
+                        tag="latest_detection",
+                        texture_tag="texture_detection",
+                        width=1280,
+                        height=720,
+                    )
                 with dpg.tab(tag="avoidance_tab", label="Obstacle Avoidance"):
-                    dpg.add_image(tag="latest_moa", texture_tag="texture_moa", width=1280, height=720)
+                    dpg.add_image(
+                        tag="latest_moa",
+                        texture_tag="texture_moa",
+                        width=1280,
+                        height=720,
+                    )
                 with dpg.tab(tag="hsv_tab", label="HSV Filter"):
-                    dpg.add_image(tag="latest_hsv", texture_tag="texture_hsv", width=1280, height=720)
+                    dpg.add_image(
+                        tag="latest_hsv",
+                        texture_tag="texture_hsv",
+                        width=1280,
+                        height=720,
+                    )
             """ with dpg.group(tag="map_group"):
                 def toggle_layer2(sender):
                     show_value = dpg.get_value(sender)
@@ -314,29 +526,48 @@ with dpg.window(tag='main_window', autosize=True, no_resize=True, on_close=save_
                             dpg.draw_line((10, 60), (100, 160), color=(255, 0, 0, 255), thickness=1)
                             dpg.draw_arrow((50, 120), (100, 115), color=(0, 200, 255), thickness=1, size=10) 
             """
-        with dpg.tab(tag="planning_tab",label="Mission Planning"):
-            with dpg.group(tag="planning_group",):
-                dpg.add_input_text(label="Mission DSL", multiline=True, )
-                with dpg.node_editor( minimap=True, minimap_location=dpg.mvNodeMiniMap_Location_BottomRight):
+        with dpg.tab(tag="planning_tab", label="Mission Planning"):
+            with dpg.group(
+                tag="planning_group",
+            ):
+                dpg.add_input_text(
+                    label="Mission DSL",
+                    multiline=True,
+                )
+                with dpg.node_editor(
+                    minimap=True,
+                    minimap_location=dpg.mvNodeMiniMap_Location_BottomRight,
+                ):
                     with dpg.node(label="Node 1"):
                         with dpg.node_attribute(label="Node A1"):
                             dpg.add_input_float(label="F1", width=150)
 
-                        with dpg.node_attribute(label="Node A2", attribute_type=dpg.mvNode_Attr_Output):
+                        with dpg.node_attribute(
+                            label="Node A2", attribute_type=dpg.mvNode_Attr_Output
+                        ):
                             dpg.add_input_float(label="F2", width=150)
 
                     with dpg.node(label="Node 2"):
                         with dpg.node_attribute(label="Node A3"):
                             dpg.add_input_float(label="F3", width=200)
 
-                        with dpg.node_attribute(label="Node A4", attribute_type=dpg.mvNode_Attr_Output):
+                        with dpg.node_attribute(
+                            label="Node A4", attribute_type=dpg.mvNode_Attr_Output
+                        ):
                             dpg.add_input_float(label="F4", width=200)
 
-with dpg.window(tag="log", label="Logging", min_size=[500,100], no_close=True, no_resize=True, horizontal_scrollbar=True):
+with dpg.window(
+    tag="log",
+    label="Logging",
+    min_size=[500, 100],
+    no_close=True,
+    no_resize=True,
+    horizontal_scrollbar=True,
+):
     dpg.add_text(tag="status_bar_text", label="log messages", wrap=500)
 
 dpg.setup_dearpygui()
-dpg.set_primary_window('main_window', True)
+dpg.set_primary_window("main_window", True)
 dpg.configure_app(init_file="dpg.ini")
 dpg.show_viewport()
 
@@ -346,7 +577,7 @@ while dpg.is_dearpygui_running():
     t0 = time.time()
     update_imagery()
     t1 = time.time()
-    #_log(f"Updating imagery took {t1-t0}")
+    # _log(f"Updating imagery took {t1-t0}")
     dpg.render_dearpygui_frame()
 
 dpg.destroy_context()

--- a/gcs/dearpygui/commander.py
+++ b/gcs/dearpygui/commander.py
@@ -13,7 +13,7 @@ TYPES = ["ANAFI", "ANAFI USA", "ANAFI Ai", "ModalAi Seeker", "ModalAi Starling"]
 STATUSES = ["offline", "idle", "TrackingTask", "PatrolTask"]
 STATUS_COLORS = [(255, 0, 0), (0, 255, 255), (200, 0, 200), (200, 0, 200)]
 
-with open("config.yaml", "r") as conf:
+with open("config.yaml") as conf:
     SECRETS = yaml.safe_load(conf)
 
 

--- a/gcs/streamlit/overview.py
+++ b/gcs/streamlit/overview.py
@@ -15,7 +15,7 @@ from util import COLORS, authenticated, connect_redis, menu, stream_to_dataframe
 if "map_server" not in st.session_state:
     st.session_state.map_server = "Google Hybrid"
 if "center" not in st.session_state:
-    st.session_state.center = {'lat':40.413552, 'lng':-79.949152}
+    st.session_state.center = {"lat": 40.413552, "lng": -79.949152}
 if "zoom_level" not in st.session_state:
     st.session_state.zoom_level = 18
 if "show_drone_markers" not in st.session_state:
@@ -32,10 +32,10 @@ st.set_page_config(
     page_icon=":military_helmet:",
     layout="wide",
     menu_items={
-        'Get help': 'https://cmusatyalab.github.io/steeleagle/',
-        'Report a bug': "https://github.com/cmusatyalab/steeleagle/issues",
-        'About': "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle"
-    }
+        "Get help": "https://cmusatyalab.github.io/steeleagle/",
+        "Report a bug": "https://github.com/cmusatyalab/steeleagle/issues",
+        "About": "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle",
+    },
 )
 
 
@@ -44,10 +44,11 @@ if not authenticated():
 
 red = connect_redis()
 
+
 @st.fragment(run_every="1s")
 def draw_map():
     m = folium.Map(
-        location=[st.session_state.center['lat'], st.session_state.center['lng']],
+        location=[st.session_state.center["lat"], st.session_state.center["lng"]],
         zoom_start=st.session_state.zoom_level,
         tiles=tiles,
     )
@@ -63,8 +64,8 @@ def draw_map():
         marker_color = 0
         for k in red.keys("telemetry:*"):
             df = stream_to_dataframe(red.xrevrange(f"{k}", "+", "-", 1))
-            last_update = (int(df.index[0].split("-")[0])/1000)
-            if time.time() - last_update <  60:
+            last_update = int(df.index[0].split("-")[0]) / 1000
+            if time.time() - last_update < 60:
                 coords = []
                 i = 0
                 drone_name = k.split(":")[-1]
@@ -75,7 +76,7 @@ def draw_map():
                     if i == 0:
                         coords.append([row["latitude"], row["longitude"]])
                         text = folium.DivIcon(
-                            icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
+                            icon_size="null",  # set the size to null so that it expands to the length of the string inside in the div
                             icon_anchor=(-20, 30),
                             html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{drone_name}  [{row["rel_altitude"]:.2f}m]<br/>{current_task}</div>',
                         )
@@ -110,10 +111,10 @@ def draw_map():
     if st.session_state.show_corridors:
         try:
             partition = []
-            with open(f"{st.secrets.waypoints}", 'r', encoding='utf-8') as f:
+            with open(f"{st.secrets.waypoints}", "r", encoding="utf-8") as f:
                 j = json.load(f)
                 for k, v in j.items():
-                    for k2, v2 in v.items(): #for each corridor
+                    for k2, v2 in v.items():  # for each corridor
                         for c in v2:
                             lon = c[0]
                             lat = c[1]
@@ -126,11 +127,11 @@ def draw_map():
     if st.session_state.show_geofence:
         try:
             fence_coords = []
-            with open(f"{st.secrets.geofence_path}", 'r', encoding='utf-8') as f:
+            with open(f"{st.secrets.geofence_path}", "r", encoding="utf-8") as f:
                 root = parser.parse(f).getroot()
                 coords = root.Document.Placemark.Polygon.outerBoundaryIs.LinearRing.coordinates.text
                 for c in coords.split():
-                    lon, lat, alt =  c.split(",")
+                    lon, lat, alt = c.split(",")
                     fence_coords.append([float(lat), float(lon)])
 
             ls = folium.PolyLine(locations=fence_coords, color="yellow")
@@ -147,12 +148,12 @@ def draw_map():
                 div_content = f"""
                         <div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">
                             {obj}&nbsp;({float(fields["confidence"]):.2f})&nbsp;[{fields["drone_id"]}]<br/>
-                            {datetime.datetime.fromtimestamp(float(fields["last_seen"])).strftime('%Y-%m-%d %H:%M:%S')}
+                            {datetime.datetime.fromtimestamp(float(fields["last_seen"])).strftime("%Y-%m-%d %H:%M:%S")}
                         </div>
                     """
 
                 text = folium.DivIcon(
-                    icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
+                    icon_size="null",  # set the size to null so that it expands to the length of the string inside in the div
                     icon_anchor=(-20, 30),
                     html=div_content,
                 )
@@ -179,13 +180,13 @@ def draw_map():
                             fields["longitude"],
                         ],
                         icon=text,
-                        tooltip=img_ref
+                        tooltip=img_ref,
                     )
                 )
 
     def update_map_props():
-        st.session_state.center = st.session_state['overview_map']['center']
-        st.session_state.zoom_level = st.session_state['overview_map']['zoom']
+        st.session_state.center = st.session_state["overview_map"]["center"]
+        st.session_state.zoom_level = st.session_state["overview_map"]["zoom"]
 
     st_folium(
         m,
@@ -195,8 +196,9 @@ def draw_map():
         layer_control=lc,
         center=st.session_state.center,
         height=720,
-        on_change=update_map_props
+        on_change=update_map_props,
     )
+
 
 menu()
 options_expander = st.expander(" **:gray-background[:wrench: Toolbar]**", expanded=True)
@@ -208,12 +210,28 @@ with options_expander:
         key="map_server",
         label=":world_map: **:blue[Tile Server]**",
         options=map_options,
-        index=0
+        index=0,
     )
-    tiles_col[1].checkbox(label="Drone Markers", key="show_drone_markers", value=st.session_state.show_drone_markers)
-    tiles_col[2].checkbox(label="Detected Objects", key="show_objects", value=st.session_state.show_objects)
-    tiles_col[3].checkbox(label="Detections Geofence", key="show_geofence", value=st.session_state.show_geofence)
-    tiles_col[4].checkbox(label="Mission Corridors", key="show_corridors", value=st.session_state.show_corridors)
+    tiles_col[1].checkbox(
+        label="Drone Markers",
+        key="show_drone_markers",
+        value=st.session_state.show_drone_markers,
+    )
+    tiles_col[2].checkbox(
+        label="Detected Objects",
+        key="show_objects",
+        value=st.session_state.show_objects,
+    )
+    tiles_col[3].checkbox(
+        label="Detections Geofence",
+        key="show_geofence",
+        value=st.session_state.show_geofence,
+    )
+    tiles_col[4].checkbox(
+        label="Mission Corridors",
+        key="show_corridors",
+        value=st.session_state.show_corridors,
+    )
 
 if st.session_state.map_server == "Google Sat":
     tileset = "https://mt0.google.com/vt/lyrs=s&hl=en&x={x}&y={y}&z={z}&s=Ga"
@@ -225,4 +243,3 @@ tiles = folium.TileLayer(
 )
 
 draw_map()
-

--- a/gcs/streamlit/overview.py
+++ b/gcs/streamlit/overview.py
@@ -1,15 +1,16 @@
 # SPDX-FileCopyrightText: 2024 Carnegie Mellon University - Satyalab
 #
 # SPDX-License-Identifier: GPL-2.0-only
-import folium
-import streamlit as st
-from streamlit_folium import st_folium
-from folium.plugins import MiniMap
-from util import  connect_redis,  menu, COLORS, authenticated, stream_to_dataframe
 import datetime
-from pykml import parser
 import json
 import time
+
+import folium
+import streamlit as st
+from folium.plugins import MiniMap
+from pykml import parser
+from streamlit_folium import st_folium
+from util import COLORS, authenticated, connect_redis, menu, stream_to_dataframe
 
 if "map_server" not in st.session_state:
     st.session_state.map_server = "Google Hybrid"

--- a/gcs/streamlit/overview.py
+++ b/gcs/streamlit/overview.py
@@ -111,7 +111,7 @@ def draw_map():
     if st.session_state.show_corridors:
         try:
             partition = []
-            with open(f"{st.secrets.waypoints}", "r", encoding="utf-8") as f:
+            with open(f"{st.secrets.waypoints}", encoding="utf-8") as f:
                 j = json.load(f)
                 for k, v in j.items():
                     for k2, v2 in v.items():  # for each corridor
@@ -127,7 +127,7 @@ def draw_map():
     if st.session_state.show_geofence:
         try:
             fence_coords = []
-            with open(f"{st.secrets.geofence_path}", "r", encoding="utf-8") as f:
+            with open(f"{st.secrets.geofence_path}", encoding="utf-8") as f:
                 root = parser.parse(f).getroot()
                 coords = root.Document.Placemark.Polygon.outerBoundaryIs.LinearRing.coordinates.text
                 for c in coords.split():

--- a/gcs/streamlit/overview.py
+++ b/gcs/streamlit/overview.py
@@ -59,6 +59,7 @@ def draw_map():
     # Draw(export=True).add_to(m)
     lc = folium.LayerControl()
     if st.session_state.show_drone_markers:
+        marker_color = 0
         for k in red.keys("telemetry:*"):
             df = stream_to_dataframe(red.xrevrange(f"{k}", "+", "-", 1))
             last_update = (int(df.index[0].split("-")[0])/1000)
@@ -103,6 +104,7 @@ def draw_map():
                                 icon=text,
                             )
                         )
+            marker_color += 1
 
     if st.session_state.show_corridors:
         try:

--- a/gcs/streamlit/overview.py
+++ b/gcs/streamlit/overview.py
@@ -10,6 +10,7 @@ import datetime
 from pykml import parser
 import json
 import time
+import math
 
 if "map_server" not in st.session_state:
     st.session_state.map_server = "Google Hybrid"
@@ -22,7 +23,7 @@ if "show_drone_markers" not in st.session_state:
 if "show_geofence" not in st.session_state:
     st.session_state.show_geofence = True
 if "show_objects" not in st.session_state:
-    st.session_state.show_objects = True
+    st.session_state.show_objects = False
 if "show_corridors" not in st.session_state:
     st.session_state.show_corridors = False
 
@@ -69,6 +70,9 @@ def draw_map():
                 for index, row in df.iterrows():
                     if i == 0:
                         coords.append([row["latitude"], row["longitude"]])
+                        bearing = int(row["bearing"])
+                        if bearing < 0:
+                            bearing = 360 - math.abs(bearing)
                         text = folium.DivIcon(
                             icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
                             icon_anchor=(-20, 30),
@@ -79,7 +83,7 @@ def draw_map():
                             icon="plane",
                             color=COLORS[marker_color],
                             prefix="glyphicon",
-                            angle=int(row["bearing"]),
+                            angle=bearing,
                         )
 
                         drone_positions.add_child(

--- a/gcs/streamlit/overview.py
+++ b/gcs/streamlit/overview.py
@@ -10,7 +10,6 @@ import datetime
 from pykml import parser
 import json
 import time
-import math
 
 if "map_server" not in st.session_state:
     st.session_state.map_server = "Google Hybrid"
@@ -67,23 +66,22 @@ def draw_map():
                 coords = []
                 i = 0
                 drone_name = k.split(":")[-1]
+                current_task = red.hget(f"drone:{drone_name}", "current_task")
+                if current_task == "":
+                    current_task = "idle"
                 for index, row in df.iterrows():
                     if i == 0:
                         coords.append([row["latitude"], row["longitude"]])
-                        bearing = int(row["bearing"])
-                        if bearing < 0:
-                            bearing = 360 - math.abs(bearing)
                         text = folium.DivIcon(
                             icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
                             icon_anchor=(-20, 30),
-                            html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{drone_name}</div>',
-                            #TODO: concatenate current task to html once it is sent i.e. <i>PatrolTask</i></div>
+                            html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{drone_name}  [{row["rel_altitude"]:.2f}m]<br/>{current_task}</div>',
                         )
                         plane = folium.Icon(
                             icon="plane",
                             color=COLORS[marker_color],
                             prefix="glyphicon",
-                            angle=bearing,
+                            angle=int(row["bearing"]) % 360,
                         )
 
                         drone_positions.add_child(

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -193,7 +193,6 @@ def draw_map():
             drone_name = k.split(":")[-1]
             drone_list.append(drone_name)
     for d in drone_list:
-        drone_name = d
         df = stream_to_dataframe(red.xrevrange(f"telemetry:{d}", "+", "-", st.session_state.trail_length))
         coords = []
         i = 0
@@ -207,7 +206,7 @@ def draw_map():
                 text = folium.DivIcon(
                     icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
                     icon_anchor=(-20, 30),
-                    html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{drone_name} [{row["rel_altitude"]:.2f}m]<br/>{current_task}</div>',
+                    html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{d} [{row["rel_altitude"]:.2f}m]<br/>{current_task}</div>',
                 )
                 plane = folium.Icon(
                     icon="plane",

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -161,7 +161,7 @@ def update_imagery():
         st.image(f"http://{st.secrets.webserver}/moa/latest.jpg?a={time.time()}")
     with col3:
         st.caption("**:traffic_light: HSV Filtering**")
-        st.image(f"http://{st.secrets.webserver}/{st.session_state.imagery_key}detected/hsv.jpg?a={time.time()}")
+        st.image(f"http://{st.secrets.webserver}/detected/drones/{st.session_state.imagery_key}/hsv.jpg?a={time.time()}")
 
 @st.fragment(run_every="1s")
 def draw_map():

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -155,7 +155,7 @@ def update_imagery():
     col1, col2, col3 = st.columns(3, vertical_alignment="top", border=True)
     with col1:
         st.caption("**:sleuth_or_spy: Object Detection**")
-        st.image(f"http://{st.secrets.webserver}/{st.session_state.imagery_key}/detected/latest.jpg?a={time.time()}")
+        st.image(f"http://{st.secrets.webserver}/detected/drones/{st.session_state.imagery_key}/latest.jpg?a={time.time()}")
     with col2:
         st.caption("**:checkered_flag: Obstacle Avoidance**")
         st.image(f"http://{st.secrets.webserver}/moa/latest.jpg?a={time.time()}")

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -11,7 +11,6 @@ from streamlit_folium import st_folium
 from folium.plugins import MiniMap
 from util import stream_to_dataframe, connect_redis, connect_zmq, get_drones, menu, COLORS, authenticated
 from st_keypressed import st_keypressed
-import math
 import uuid
 
 
@@ -252,7 +251,7 @@ def draw_map():
         "alt": "float",
         }
 
-        ret = red.xrevrange(f"slam", "+", "-", st.session_state.trail_length)
+        ret = red.xrevrange("slam", "+", "-", st.session_state.trail_length)
         if len(ret) > 0:
             df = stream_to_dataframe(ret, types=TYPES)
             slam_coords = []
@@ -300,7 +299,7 @@ def draw_map():
         "lon": "float",
         }
 
-        ret = red.xrevrange(f"landing_spot", "+", "-", 1)
+        ret = red.xrevrange("landing_spot", "+", "-", 1)
         if len(ret) > 0:
             df = stream_to_dataframe(ret, types=TYPES)
             landing_coords = []

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -193,6 +193,7 @@ def draw_map():
             drone_name = k.split(":")[-1]
             drone_list.append(drone_name)
     for d in drone_list:
+        drone_name = d
         df = stream_to_dataframe(red.xrevrange(f"telemetry:{d}", "+", "-", st.session_state.trail_length))
         coords = []
         i = 0

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -193,6 +193,9 @@ def draw_map():
             coords = []
             i = 0
             drone_name = k.split(":")[-1]
+            current_task = red.hget(f"drone:{drone_name}", "current_task")
+            if current_task == "":
+                current_task = "idle"
             for index, row in df.iterrows():
                 if i % 10 == 0:
                     coords.append([row["latitude"], row["longitude"]])
@@ -200,14 +203,13 @@ def draw_map():
                     text = folium.DivIcon(
                         icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
                         icon_anchor=(-20, 30),
-                        html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{drone_name} [{row["rel_altitude"]:.2f}m]',
-                        #TODO: concatenate current task to html once it is sent i.e. <i>PatrolTask</i></div>
+                        html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{drone_name} [{row["rel_altitude"]:.2f}m]<br/>{current_task}</div>',
                     )
                     plane = folium.Icon(
                         icon="plane",
                         color=COLORS[marker_color],
                         prefix="glyphicon",
-                        angle=int(row["bearing"]),
+                        angle=int(row["bearing"]) % 360,
                     )
 
                     fg.add_child(

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -26,7 +26,7 @@ import protocol.controlplane_pb2 as controlplane
 if "map_server" not in st.session_state:
     st.session_state.map_server = "Google Hybrid"
 if "center" not in st.session_state:
-    st.session_state.center = {'lat':40.413552, 'lng':-79.949152}
+    st.session_state.center = {"lat": 40.413552, "lng": -79.949152}
 if "tracking_selection" not in st.session_state:
     st.session_state.tracking_selection = None
 if "selected_drones" not in st.session_state:
@@ -34,7 +34,7 @@ if "selected_drones" not in st.session_state:
 if "script_file" not in st.session_state:
     st.session_state.script_file = None
 if "inactivity_time" not in st.session_state:
-    st.session_state.inactivity_time = 1 #min
+    st.session_state.inactivity_time = 1  # min
 if "trail_length" not in st.session_state:
     st.session_state.trail_length = 100
 if "armed" not in st.session_state:
@@ -70,10 +70,10 @@ st.set_page_config(
     page_icon=":military_helmet:",
     layout="wide",
     menu_items={
-        'Get help': 'https://cmusatyalab.github.io/steeleagle/',
-        'Report a bug': "https://github.com/cmusatyalab/steeleagle/issues",
-        'About': "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle"
-    }
+        "Get help": "https://cmusatyalab.github.io/steeleagle/",
+        "Report a bug": "https://github.com/cmusatyalab/steeleagle/issues",
+        "About": "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle",
+    },
 )
 
 if "zmq" not in st.session_state:
@@ -84,6 +84,7 @@ if not authenticated():
 
 red = connect_redis()
 
+
 def change_center():
     if st.session_state.tracking_selection is not None:
         df = stream_to_dataframe(
@@ -92,7 +93,7 @@ def change_center():
             )
         )
         for index, row in df.iterrows():
-            st.session_state.center = {'lat': row["latitude"], 'lng': row["longitude"]}
+            st.session_state.center = {"lat": row["latitude"], "lng": row["longitude"]}
 
 
 def run_flightscript():
@@ -101,7 +102,7 @@ def run_flightscript():
     else:
         filename = f"{time.time_ns()}.ms"
         path = f"{st.secrets.scripts_path}/{filename}"
-        with ZipFile(path, 'w') as z:
+        with ZipFile(path, "w") as z:
             for file in st.session_state.script_file:
                 z.writestr(file.name, file.read())
 
@@ -120,6 +121,7 @@ def run_flightscript():
             icon="\u2601",
         )
 
+
 def enable_manual():
     req = controlplane.Request()
     req.seq_num = int(time.time())
@@ -129,9 +131,8 @@ def enable_manual():
     req.msn.action = controlplane.MissionAction.STOP
     st.session_state.zmq.send(req.SerializeToString())
     rep = st.session_state.zmq.recv()
-    st.toast(
-        f"Telling drone {req.veh.drone_ids} to halt! Kill signal sent."
-    )
+    st.toast(f"Telling drone {req.veh.drone_ids} to halt! Kill signal sent.")
+
 
 def rth():
     req = controlplane.Request()
@@ -144,12 +145,15 @@ def rth():
     rep = st.session_state.zmq.recv()
     st.toast(f"Instructed {req.veh.drone_ids} to return to home!")
 
-@st.fragment(run_every=f"{1/st.session_state.imagery_framerate}s")
+
+@st.fragment(run_every=f"{1 / st.session_state.imagery_framerate}s")
 def update_imagery():
     drone_list = []
     for k in red.keys("drone:*"):
         last_seen = float(red.hget(k, "last_seen"))
-        if time.time() - last_seen < st.session_state.inactivity_time * 60: # minutes -> seconds
+        if (
+            time.time() - last_seen < st.session_state.inactivity_time * 60
+        ):  # minutes -> seconds
             drone_name = k.split(":")[-1]
             drone_list.append(drone_name)
 
@@ -157,33 +161,57 @@ def update_imagery():
         key="imagery_key",
         label=" **:blue-background[:material/photo_library: Imagery]**",
         options=drone_list,
-        index=0
+        index=0,
     )
-    st.image(f"http://{st.secrets.webserver}/raw/{st.session_state.imagery_key}/latest.jpg?a={time.time()}", use_container_width=True)
+    st.image(
+        f"http://{st.secrets.webserver}/raw/{st.session_state.imagery_key}/latest.jpg?a={time.time()}",
+        use_container_width=True,
+    )
     col1, col2, col3 = st.columns(3, vertical_alignment="top", border=True)
     with col1:
         st.caption("**:sleuth_or_spy: Object Detection**")
-        st.image(f"http://{st.secrets.webserver}/detected/drones/{st.session_state.imagery_key}/latest.jpg?a={time.time()}")
+        st.image(
+            f"http://{st.secrets.webserver}/detected/drones/{st.session_state.imagery_key}/latest.jpg?a={time.time()}"
+        )
     with col2:
         st.caption("**:checkered_flag: Obstacle Avoidance**")
         st.image(f"http://{st.secrets.webserver}/moa/latest.jpg?a={time.time()}")
     with col3:
         st.caption("**:traffic_light: HSV Filtering**")
-        st.image(f"http://{st.secrets.webserver}/detected/drones/{st.session_state.imagery_key}/hsv.jpg?a={time.time()}")
+        st.image(
+            f"http://{st.secrets.webserver}/detected/drones/{st.session_state.imagery_key}/hsv.jpg?a={time.time()}"
+        )
+
 
 @st.fragment(run_every="1s")
 def draw_map():
     m = folium.Map(
-        location=[st.session_state.center['lat'], st.session_state.center['lng']],
+        location=[st.session_state.center["lat"], st.session_state.center["lng"]],
         zoom_start=st.session_state.zoom_level,
         tiles=tiles,
     )
 
     col1, col2, col3, col4 = st.columns(4)
-    col1.checkbox(label="Drone Markers", key="show_drone_markers", value=st.session_state.show_drone_markers)
-    col2.checkbox(label="Historical Tracks", key="show_gps_tracks", value=st.session_state.show_gps_tracks)
-    col3.checkbox(label="SLAM Track", key="show_slam_track", value=st.session_state.show_slam_track)
-    col4.checkbox(label="Landing Spot", key="show_landing_spot", value=st.session_state.show_landing_spot)
+    col1.checkbox(
+        label="Drone Markers",
+        key="show_drone_markers",
+        value=st.session_state.show_drone_markers,
+    )
+    col2.checkbox(
+        label="Historical Tracks",
+        key="show_gps_tracks",
+        value=st.session_state.show_gps_tracks,
+    )
+    col3.checkbox(
+        label="SLAM Track",
+        key="show_slam_track",
+        value=st.session_state.show_slam_track,
+    )
+    col4.checkbox(
+        label="Landing Spot",
+        key="show_landing_spot",
+        value=st.session_state.show_landing_spot,
+    )
 
     MiniMap(toggle_display=True, tile_layer=tiles).add_to(m)
     fg = folium.FeatureGroup(name="Drone Markers")
@@ -197,11 +225,15 @@ def draw_map():
     drone_list = []
     for k in red.keys("drone:*"):
         last_seen = float(red.hget(k, "last_seen"))
-        if time.time() - last_seen < st.session_state.inactivity_time * 60: # minutes -> seconds
+        if (
+            time.time() - last_seen < st.session_state.inactivity_time * 60
+        ):  # minutes -> seconds
             drone_name = k.split(":")[-1]
             drone_list.append(drone_name)
     for d in drone_list:
-        df = stream_to_dataframe(red.xrevrange(f"telemetry:{d}", "+", "-", st.session_state.trail_length))
+        df = stream_to_dataframe(
+            red.xrevrange(f"telemetry:{d}", "+", "-", st.session_state.trail_length)
+        )
         coords = []
         i = 0
         current_task = red.hget(f"drone:{d}", "current_task")
@@ -212,7 +244,7 @@ def draw_map():
                 coords.append([row["latitude"], row["longitude"]])
             if st.session_state.show_drone_markers and i == 0:
                 text = folium.DivIcon(
-                    icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
+                    icon_size="null",  # set the size to null so that it expands to the length of the string inside in the div
                     icon_anchor=(-20, 30),
                     html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:{COLORS[marker_color]};">{d} [{row["rel_altitude"]:.2f}m]<br/>{current_task}</div>',
                 )
@@ -250,14 +282,14 @@ def draw_map():
             ls.add_to(tracks)
             marker_color += 1
 
-
     if st.session_state.show_slam_track:
-        TYPES={"pose_x": "float",
-        "pose_y": "float",
-        "pose_z": "float",
-        "lat": "float",
-        "lon": "float",
-        "alt": "float",
+        TYPES = {
+            "pose_x": "float",
+            "pose_y": "float",
+            "pose_z": "float",
+            "lat": "float",
+            "lon": "float",
+            "alt": "float",
         }
 
         ret = red.xrevrange("slam", "+", "-", st.session_state.trail_length)
@@ -269,7 +301,7 @@ def draw_map():
                 slam_coords.append([row["lat"], row["lon"]])
                 if i == 0:
                     text = folium.DivIcon(
-                        icon_size="null", #set the size to null so that it expands to the length of the string inside in the div
+                        icon_size="null",  # set the size to null so that it expands to the length of the string inside in the div
                         icon_anchor=(-20, 30),
                         html=f'<div style="color:white;font-size: 12pt;font-weight: bold;background-color:#c0c125;">{row["alt"]:.2f}m MSL</div>',
                     )
@@ -277,7 +309,7 @@ def draw_map():
                         icon="plane",
                         color="beige",
                         prefix="glyphicon",
-                        #angle=int(row["bearing"]),
+                        # angle=int(row["bearing"]),
                     )
 
                     slam_track.add_child(
@@ -304,8 +336,9 @@ def draw_map():
             ls.add_to(slam_track)
 
     if st.session_state.show_landing_spot:
-        TYPES={"lat": "float",
-        "lon": "float",
+        TYPES = {
+            "lat": "float",
+            "lon": "float",
         }
 
         ret = red.xrevrange("landing_spot", "+", "-", 1)
@@ -320,27 +353,27 @@ def draw_map():
                 radius=2,
                 color="orange",
                 weight=2,
-                #fill_opacity=0.6,
-                #opacity=1,
-                #fill_color="orange",
-                #fill=False,  # gets overridden by fill_color
+                # fill_opacity=0.6,
+                # opacity=1,
+                # fill_color="orange",
+                # fill=False,  # gets overridden by fill_color
             )
 
             circle.add_to(landing_spot)
 
     def update_map_props():
-        st.session_state.center = st.session_state['overview_map']['center']
-        st.session_state.zoom_level = st.session_state['overview_map']['zoom']
+        st.session_state.center = st.session_state["overview_map"]["center"]
+        st.session_state.zoom_level = st.session_state["overview_map"]["zoom"]
 
     output = st_folium(
         m,
         key="overview_map",
         use_container_width=True,
         feature_group_to_add=[fg, tracks, slam_track, landing_spot],
-        #layer_control=lc,
+        # layer_control=lc,
         center=st.session_state.center,
         height=500,
-        on_change=update_map_props
+        on_change=update_map_props,
     )
 
 
@@ -354,7 +387,7 @@ with options_expander:
         key="map_server",
         label=":world_map: **:blue[Tile Server]**",
         options=map_options,
-        index=0
+        index=0,
     )
 
     tiles_col[1].selectbox(
@@ -365,8 +398,13 @@ with options_expander:
         placeholder="Select a drone to track...",
     )
 
-
-    tiles_col[2].number_input(":heartbeat: **:red[Active Threshold (min)]**", step=1, min_value=1, key="inactivity_time", max_value=600000)
+    tiles_col[2].number_input(
+        ":heartbeat: **:red[Active Threshold (min)]**",
+        step=1,
+        min_value=1,
+        key="inactivity_time",
+        max_value=600000,
+    )
 
     if st.session_state.map_server == "Google Sat":
         tileset = "https://mt0.google.com/vt/lyrs=s&hl=en&x={x}&y={y}&z={z}&s=Ga"
@@ -377,32 +415,53 @@ with options_expander:
         name=st.session_state.map_server, tiles=tileset, attr="Google", max_zoom=22
     )
 
-    tiles_col[3].number_input(":straight_ruler: **:gray[Trail Length]**", step=25, min_value=25, max_value=200, key="trail_length")
-    mode = "**:green-background[:joystick: Manual Control Enabled (armed)]**" if st.session_state.armed else "**:red-background[:joystick: Manual Control Disabled (disarmed)]**"
-    tiles_col[4].number_input(key = "imagery_framerate", label=":camera: **:orange[Imagery FPS]**", min_value=1, max_value=10, step=1, value=2, format="%0d")
+    tiles_col[3].number_input(
+        ":straight_ruler: **:gray[Trail Length]**",
+        step=25,
+        min_value=25,
+        max_value=200,
+        key="trail_length",
+    )
+    mode = (
+        "**:green-background[:joystick: Manual Control Enabled (armed)]**"
+        if st.session_state.armed
+        else "**:red-background[:joystick: Manual Control Disabled (disarmed)]**"
+    )
+    tiles_col[4].number_input(
+        key="imagery_framerate",
+        label=":camera: **:orange[Imagery FPS]**",
+        min_value=1,
+        max_value=10,
+        step=1,
+        value=2,
+        format="%0d",
+    )
 
 col1, col2 = st.columns([0.6, 0.4])
 with col1:
     update_imagery()
 
 with col2:
-        st.caption("**:blue-background[:globe_with_meridians: Flight Tracking]**")
-        draw_map()
+    st.caption("**:blue-background[:globe_with_meridians: Flight Tracking]**")
+    draw_map()
 
 with st.sidebar:
     drone_list = get_drones()
     if len(drone_list) > 0:
-        st.pills(label=":helicopter: **:orange[Swarm Control]** :helicopter:",
+        st.pills(
+            label=":helicopter: **:orange[Swarm Control]** :helicopter:",
             options=drone_list.keys(),
             default=drone_list.keys(),
             format_func=lambda option: drone_list[option],
             selection_mode="multi",
-             key="selected_drones"
-             )
+            key="selected_drones",
+        )
 
     else:
         st.caption("No active drones.")
-    st.toggle(key="armed", label=":safety_vest: Arm Swarm?", value=st.session_state.armed)
+    st.toggle(
+        key="armed", label=":safety_vest: Arm Swarm?", value=st.session_state.armed
+    )
     st.caption(mode)
 
     st.session_state.script_file = st.file_uploader(
@@ -410,8 +469,8 @@ with st.sidebar:
         label="**:violet[Upload Autonomous Mission Script]**",
         help="Upload a flight script.",
         type=["kml", "dsl"],
-        label_visibility='visible',
-        accept_multiple_files=True
+        label_visibility="visible",
+        accept_multiple_files=True,
     )
     st.button(
         key="autonomous_button",
@@ -440,18 +499,74 @@ with st.sidebar:
 
     if st.session_state.armed and len(st.session_state.selected_drones) > 0:
         c1, c2 = st.columns(spec=2, gap="small")
-        c1.number_input(key="pitch_speed", label="Pitch (m/s)", min_value=0.0, max_value=5.0, value=2.0, step=0.5, format="%f")
-        c2.number_input(key = "thrust_speed", label="Thrust (m/s)", min_value=0.0, max_value=5.0, value=2.0, step=0.5, format="%f")
+        c1.number_input(
+            key="pitch_speed",
+            label="Pitch (m/s)",
+            min_value=0.0,
+            max_value=5.0,
+            value=2.0,
+            step=0.5,
+            format="%f",
+        )
+        c2.number_input(
+            key="thrust_speed",
+            label="Thrust (m/s)",
+            min_value=0.0,
+            max_value=5.0,
+            value=2.0,
+            step=0.5,
+            format="%f",
+        )
         c3, c4 = st.columns(spec=2, gap="small")
-        c3.number_input(key = "yaw_speed", label="Yaw (deg/s)", min_value=0, max_value=180, step=15, value=45, format="%d")
-        c4.number_input(key = "roll_speed", label="Roll (m/s)", min_value=0.0, max_value=5.0, value=2.0, step=0.5, format="%f")
+        c3.number_input(
+            key="yaw_speed",
+            label="Yaw (deg/s)",
+            min_value=0,
+            max_value=180,
+            step=15,
+            value=45,
+            format="%d",
+        )
+        c4.number_input(
+            key="roll_speed",
+            label="Roll (m/s)",
+            min_value=0.0,
+            max_value=5.0,
+            value=2.0,
+            step=0.5,
+            format="%f",
+        )
         c5, c6 = st.columns(spec=2, gap="small")
-        mode = "**Gimbal Relative**" if st.session_state.gimbal_relative_mode else "**Gimbal Absolute**"
-        on = c5.toggle(key="gimbal_relative_mode", label=mode, value=st.session_state.gimbal_relative_mode)
+        mode = (
+            "**Gimbal Relative**"
+            if st.session_state.gimbal_relative_mode
+            else "**Gimbal Absolute**"
+        )
+        on = c5.toggle(
+            key="gimbal_relative_mode",
+            label=mode,
+            value=st.session_state.gimbal_relative_mode,
+        )
         if on:
-            c5.number_input(key = "gimbal_rel", label="Gimbal Pitch (deg/s)", min_value=0, max_value=30, step=5, value=15, format="%d")
+            c5.number_input(
+                key="gimbal_rel",
+                label="Gimbal Pitch (deg/s)",
+                min_value=0,
+                max_value=30,
+                step=5,
+                value=15,
+                format="%d",
+            )
         else:
-            c5.slider(key = "gimbal_abs", label="Gimbal Pitch (deg)", min_value=-90, max_value=90, step=15, value=45, format="%d")
+            c5.slider(
+                key="gimbal_abs",
+                label="Gimbal Pitch (deg)",
+                min_value=-90,
+                max_value=90,
+                step=15,
+                value=45,
+                format="%d",
+            )
 
         key_pressed = st_keypressed()
         req = controlplane.Request()
@@ -460,7 +575,7 @@ with st.sidebar:
         for d in st.session_state.selected_drones:
             req.veh.drone_ids.append(d)
 
-        #req.cmd.manual = True
+        # req.cmd.manual = True
         st.caption(f"keypressed={key_pressed}")
         if key_pressed == "t":
             req.veh.action = controlplane.VehicleAction.TAKEOFF
@@ -493,7 +608,9 @@ with st.sidebar:
 
             if gimbal_pitch != 0 and st.session_state.gimbal_relative_mode:
                 req.veh.gimbal_pose.pitch = gimbal_pitch
-                req.veh.gimbal_pose.control_mode = common.PoseControlMode.POSITION_RELATIVE
+                req.veh.gimbal_pose.control_mode = (
+                    common.PoseControlMode.POSITION_RELATIVE
+                )
             elif yaw == 0 and pitch == 0 and roll == 0 and thrust == 0:
                 req.veh.action = controlplane.VehicleAction.HOVER
             else:
@@ -503,10 +620,10 @@ with st.sidebar:
                 req.veh.velocity_body.up_vel = thrust
             if not st.session_state.gimbal_relative_mode:
                 req.veh.gimbal_pose.pitch = st.session_state.gimbal_abs
-                req.veh.gimbal_pose.control_mode = common.PoseControlMode.POSITION_ABSOLUTE
+                req.veh.gimbal_pose.control_mode = (
+                    common.PoseControlMode.POSITION_ABSOLUTE
+                )
             st.caption(req)
         key_pressed = None
         st.session_state.zmq.send(req.SerializeToString())
         rep = st.session_state.zmq.recv()
-
-

--- a/gcs/streamlit/pages/control.py
+++ b/gcs/streamlit/pages/control.py
@@ -1,18 +1,27 @@
 # SPDX-FileCopyrightText: 2024 Carnegie Mellon University - Satyalab
 #
 # SPDX-License-Identifier: GPL-2.0-only
-import protocol.controlplane_pb2 as controlplane
-import protocol.common_pb2 as common
 import time
+import uuid
 from zipfile import ZipFile
+
 import folium
 import streamlit as st
-from streamlit_folium import st_folium
 from folium.plugins import MiniMap
-from util import stream_to_dataframe, connect_redis, connect_zmq, get_drones, menu, COLORS, authenticated
 from st_keypressed import st_keypressed
-import uuid
+from streamlit_folium import st_folium
+from util import (
+    COLORS,
+    authenticated,
+    connect_redis,
+    connect_zmq,
+    get_drones,
+    menu,
+    stream_to_dataframe,
+)
 
+import protocol.common_pb2 as common
+import protocol.controlplane_pb2 as controlplane
 
 if "map_server" not in st.session_state:
     st.session_state.map_server = "Google Hybrid"

--- a/gcs/streamlit/pages/monitoring.py
+++ b/gcs/streamlit/pages/monitoring.py
@@ -69,6 +69,8 @@ def plot_data():
             else:
                 slam_status = ":red-badge[:material/globe_location_pin: SLAM Not Localized]"
 
+            current_task = red.hget(k, "current_task")
+            task_status = f":blue-badge[:material/format_list_numbered: {current_task}]"
             df = stream_to_dataframe(red.xrevrange(f"telemetry:{drone_name}", "+", "-", 1))
             column_config={
                     "_index": None,
@@ -106,7 +108,7 @@ def plot_data():
                 }
             cols[i%2].markdown(f"### **{drone_name} ({drone_model})**")
             cols[i%2].image(f"http://{st.secrets.webserver}/raw/{drone_name}/latest.jpg?a={time.time()}", use_container_width=True)
-            cols[i%2].markdown(f"**{bat_status}{mag_status}{sat_status}{slam_status}**")
+            cols[i%2].markdown(f"**{task_status}{bat_status}{mag_status}{sat_status}{slam_status}**")
             cols[i%2].dataframe(df, column_config=column_config)
             #cols[i%2].map(df, latitude="Lat", longitude="Lon", size="5", use_container_width=False, width=100)
             i += 1

--- a/gcs/streamlit/pages/monitoring.py
+++ b/gcs/streamlit/pages/monitoring.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 import time
+
 import streamlit as st
-from util import stream_to_dataframe, connect_redis, connect_zmq, menu, authenticated
+from util import authenticated, connect_redis, connect_zmq, menu, stream_to_dataframe
 
 st.set_page_config(
     page_title="Commander",

--- a/gcs/streamlit/pages/monitoring.py
+++ b/gcs/streamlit/pages/monitoring.py
@@ -20,13 +20,15 @@ if "zmq" not in st.session_state:
     st.session_state.zmq = connect_zmq()
 if "inactivity_time" not in st.session_state:
     st.session_state.inactivity_time = 1 #min
+if "refresh_rate" not in st.session_state:
+    st.session_state.refresh_rate = 2 #sec
 
 if not authenticated():
     st.stop()  # Do not continue if not authenticated
 
 red = connect_redis()
 
-@st.fragment(run_every="1s")
+@st.fragment(run_every=st.session_state.refresh_rate)
 def plot_data():
    cols = st.columns(2)
    i = 0
@@ -113,5 +115,6 @@ def plot_data():
 menu()
 with st.sidebar:
     st.number_input(":heartbeat: **:red[Active Threshold (min)]**", step=1, min_value=1, key="inactivity_time", max_value=10)
+    st.number_input(":stopwatch: **:green[Refresh Rate (sec)]**", step=1, min_value=1, key="refresh_rate", max_value=5)
 st.header(f":helicopter: **:orange[Active Drones]** (last {st.session_state.inactivity_time} mins)")
 plot_data()

--- a/gcs/streamlit/pages/monitoring.py
+++ b/gcs/streamlit/pages/monitoring.py
@@ -11,38 +11,41 @@ st.set_page_config(
     page_icon=":military_helmet:",
     layout="wide",
     menu_items={
-        'Get help': 'https://cmusatyalab.github.io/steeleagle/',
-        'Report a bug': "https://github.com/cmusatyalab/steeleagle/issues",
-        'About': "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle"
-    }
+        "Get help": "https://cmusatyalab.github.io/steeleagle/",
+        "Report a bug": "https://github.com/cmusatyalab/steeleagle/issues",
+        "About": "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle",
+    },
 )
 
 if "zmq" not in st.session_state:
     st.session_state.zmq = connect_zmq()
 if "inactivity_time" not in st.session_state:
-    st.session_state.inactivity_time = 1 #min
+    st.session_state.inactivity_time = 1  # min
 if "refresh_rate" not in st.session_state:
-    st.session_state.refresh_rate = 2 #sec
+    st.session_state.refresh_rate = 2  # sec
 
 if not authenticated():
     st.stop()  # Do not continue if not authenticated
 
 red = connect_redis()
 
+
 @st.fragment(run_every=st.session_state.refresh_rate)
 def plot_data():
-   cols = st.columns(2)
-   i = 0
-   for k in red.keys("drone:*"):
+    cols = st.columns(2)
+    i = 0
+    for k in red.keys("drone:*"):
         last_seen = float(red.hget(k, "last_seen"))
-        if time.time() - last_seen <  st.session_state.inactivity_time * 60: # minutes -> seconds
+        if (
+            time.time() - last_seen < st.session_state.inactivity_time * 60
+        ):  # minutes -> seconds
             drone_name = k.split(":")[-1]
             drone_model = red.hget(k, "model")
             if drone_model == "":
                 drone_model = "unknown"
             bat = int(red.hget(k, "battery"))
             if bat == 0:
-               bat_status = ":green-badge[:material/battery_full: Nominal Battery]"
+                bat_status = ":green-badge[:material/battery_full: Nominal Battery]"
             elif bat == 1:
                 bat_status = ":orange-badge[:material/battery_3_bar: Low Battery]"
             else:
@@ -54,7 +57,9 @@ def plot_data():
             elif mag == 1:
                 mag_status = ":orange-badge[:material/explore: Magnetic Perturbation]"
             else:
-                mag_status = ":red-badge[:material/explore: Strong Magnetic Interference]"
+                mag_status = (
+                    ":red-badge[:material/explore: Strong Magnetic Interference]"
+                )
 
             sats = int(red.hget(k, "sats"))
             if sats == 0:
@@ -66,58 +71,83 @@ def plot_data():
 
             slam = red.hget(k, "slam_registering")
             if slam:
-                slam_status = ":green-badge[:material/globe_location_pin: SLAM Localized]"
+                slam_status = (
+                    ":green-badge[:material/globe_location_pin: SLAM Localized]"
+                )
             else:
-                slam_status = ":red-badge[:material/globe_location_pin: SLAM Not Localized]"
+                slam_status = (
+                    ":red-badge[:material/globe_location_pin: SLAM Not Localized]"
+                )
 
             current_task = red.hget(k, "current_task")
             task_status = f":blue-badge[:material/format_list_numbered: {current_task}]"
-            df = stream_to_dataframe(red.xrevrange(f"telemetry:{drone_name}", "+", "-", 1))
-            column_config={
-                    "_index": None,
-                    "latitude": st.column_config.NumberColumn(
-                        "Lat",
-                        format="%.3f",
-                    ),
-                    "longitude": st.column_config.NumberColumn(
-                        "Lon",
-                        format="%.3f",
-                    ),
-                    "rel_altitude": st.column_config.NumberColumn(
-                        "Alt (AGL)",
-                        format="%.1f",
-                    ),
-                    "abs_altitude": st.column_config.NumberColumn(
-                        "Alt (MSL)",
-                        format="%.1f",
-                    ),
-                    "sats": st.column_config.NumberColumn(
-                        "# Sats",
-                        format="%d",
-                    ),
-                    "bearing": st.column_config.NumberColumn(
-                        "Bearing",
-                        format="%d",
-                    ),
-                    "battery": st.column_config.ProgressColumn(
-                        "Battery",
-                        format="%d",
-                        min_value=0,
-                        max_value=100,
-                    ),
-                    "mag": None,
-                }
-            cols[i%2].markdown(f"### **{drone_name} ({drone_model})**")
-            cols[i%2].image(f"http://{st.secrets.webserver}/raw/{drone_name}/latest.jpg?a={time.time()}", use_container_width=True)
-            cols[i%2].markdown(f"**{task_status}{bat_status}{mag_status}{sat_status}{slam_status}**")
-            cols[i%2].dataframe(df, column_config=column_config)
-            #cols[i%2].map(df, latitude="Lat", longitude="Lon", size="5", use_container_width=False, width=100)
+            df = stream_to_dataframe(
+                red.xrevrange(f"telemetry:{drone_name}", "+", "-", 1)
+            )
+            column_config = {
+                "_index": None,
+                "latitude": st.column_config.NumberColumn(
+                    "Lat",
+                    format="%.3f",
+                ),
+                "longitude": st.column_config.NumberColumn(
+                    "Lon",
+                    format="%.3f",
+                ),
+                "rel_altitude": st.column_config.NumberColumn(
+                    "Alt (AGL)",
+                    format="%.1f",
+                ),
+                "abs_altitude": st.column_config.NumberColumn(
+                    "Alt (MSL)",
+                    format="%.1f",
+                ),
+                "sats": st.column_config.NumberColumn(
+                    "# Sats",
+                    format="%d",
+                ),
+                "bearing": st.column_config.NumberColumn(
+                    "Bearing",
+                    format="%d",
+                ),
+                "battery": st.column_config.ProgressColumn(
+                    "Battery",
+                    format="%d",
+                    min_value=0,
+                    max_value=100,
+                ),
+                "mag": None,
+            }
+            cols[i % 2].markdown(f"### **{drone_name} ({drone_model})**")
+            cols[i % 2].image(
+                f"http://{st.secrets.webserver}/raw/{drone_name}/latest.jpg?a={time.time()}",
+                use_container_width=True,
+            )
+            cols[i % 2].markdown(
+                f"**{task_status}{bat_status}{mag_status}{sat_status}{slam_status}**"
+            )
+            cols[i % 2].dataframe(df, column_config=column_config)
+            # cols[i%2].map(df, latitude="Lat", longitude="Lon", size="5", use_container_width=False, width=100)
             i += 1
 
 
 menu()
 with st.sidebar:
-    st.number_input(":heartbeat: **:red[Active Threshold (min)]**", step=1, min_value=1, key="inactivity_time", max_value=10)
-    st.number_input(":stopwatch: **:green[Refresh Rate (sec)]**", step=1, min_value=1, key="refresh_rate", max_value=5)
-st.header(f":helicopter: **:orange[Active Drones]** (last {st.session_state.inactivity_time} mins)")
+    st.number_input(
+        ":heartbeat: **:red[Active Threshold (min)]**",
+        step=1,
+        min_value=1,
+        key="inactivity_time",
+        max_value=10,
+    )
+    st.number_input(
+        ":stopwatch: **:green[Refresh Rate (sec)]**",
+        step=1,
+        min_value=1,
+        key="refresh_rate",
+        max_value=5,
+    )
+st.header(
+    f":helicopter: **:orange[Active Drones]** (last {st.session_state.inactivity_time} mins)"
+)
 plot_data()

--- a/gcs/streamlit/pages/monitoring.py
+++ b/gcs/streamlit/pages/monitoring.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 import time
 import streamlit as st
-from util import stream_to_dataframe, connect_redis, connect_zmq, get_drones, menu, COLORS, authenticated
+from util import stream_to_dataframe, connect_redis, connect_zmq, menu, authenticated
 
 st.set_page_config(
     page_title="Commander",

--- a/gcs/streamlit/pages/plan.py
+++ b/gcs/streamlit/pages/plan.py
@@ -3,15 +3,14 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 import streamlit as st
-from streamlit_ace import st_ace
-from util import menu, authenticated
 import streamlit.components.v1 as components
-from streamlit_oauth import OAuth2Component
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
-
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+from streamlit_ace import st_ace
+from streamlit_oauth import OAuth2Component
+from util import authenticated, menu
 
 sample="""Task {
     Detect patrol_route {

--- a/gcs/streamlit/pages/plan.py
+++ b/gcs/streamlit/pages/plan.py
@@ -12,7 +12,7 @@ from streamlit_ace import st_ace
 from streamlit_oauth import OAuth2Component
 from util import authenticated, menu
 
-sample="""Task {
+sample = """Task {
     Detect patrol_route {
         way_points: <Hex>,
         gimbal_pitch: -30.0,
@@ -49,24 +49,24 @@ st.set_page_config(
     page_icon=":military_helmet:",
     layout="wide",
     menu_items={
-        'Get help': 'https://cmusatyalab.github.io/steeleagle/',
-        'Report a bug': "https://github.com/cmusatyalab/steeleagle/issues",
-        'About': "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle"
-    }
+        "Get help": "https://cmusatyalab.github.io/steeleagle/",
+        "Report a bug": "https://github.com/cmusatyalab/steeleagle/issues",
+        "About": "SteelEagle - Automated drone flights for visual inspection tasks\n https://github.com/cmusatyalab/steeleagle",
+    },
 )
 
 if not authenticated():
     st.stop()  # Do not continue if not authenticated
 
 
-
 def fetch_mymaps():
     creds = Credentials(
-        st.session_state.auth['token']['access_token'],
-        refresh_token=st.session_state.auth['token']['refresh_token'],
+        st.session_state.auth["token"]["access_token"],
+        refresh_token=st.session_state.auth["token"]["refresh_token"],
         token_uri=st.secrets.oauth.token_endpoint,
         client_id=st.secrets.oauth.client_id,
-        client_secret=st.secrets.oauth.client_secret)
+        client_secret=st.secrets.oauth.client_secret,
+    )
 
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -87,7 +87,7 @@ def fetch_mymaps():
         items = results.get("files", [])
 
         for file in items:
-            st.session_state.file_list[file['id']] = file['name']
+            st.session_state.file_list[file["id"]] = file["name"]
     except HttpError as error:
         st.error(f"An error occurred fetching files from Google Drive: {error}")
 
@@ -97,12 +97,14 @@ c1, c2 = st.columns(spec=[0.5, 0.5], gap="small")
 with c1:
     if "auth" not in st.session_state:
         # create a button to start the OAuth2 flow
-        oauth2 = OAuth2Component(st.secrets.oauth.client_id,
-                                 st.secrets.oauth.client_secret,
-                                 st.secrets.oauth.auth_endpoint,
-                                 st.secrets.oauth.token_endpoint,
-                                 st.secrets.oauth.token_endpoint,
-                                 st.secrets.oauth.revoke_endpoint)
+        oauth2 = OAuth2Component(
+            st.secrets.oauth.client_id,
+            st.secrets.oauth.client_secret,
+            st.secrets.oauth.auth_endpoint,
+            st.secrets.oauth.token_endpoint,
+            st.secrets.oauth.token_endpoint,
+            st.secrets.oauth.revoke_endpoint,
+        )
         result = oauth2.authorize_button(
             name="Log in to Google Drive",
             icon="https://www.google.com/favicon.ico",
@@ -111,7 +113,7 @@ with c1:
             key="google",
             extras_params={"prompt": "consent", "access_type": "offline"},
             use_container_width=True,
-            pkce='S256',
+            pkce="S256",
         )
 
         if result:
@@ -120,18 +122,32 @@ with c1:
 
     else:
         fetch_mymaps()
-        st.selectbox(label=":world_map: **:blue[Load Map]**", options=st.session_state.file_list.keys(),  format_func=lambda option: st.session_state.file_list[option], key="map_id", placeholder="Select a map to load from MyMaps...")
-        components.iframe(f"https://www.google.com/maps/d/u/0/embed?mid={st.session_state.map_id}", height=600, scrolling=True)
-        st.link_button(label="Download KML", type="primary", url=f"https://www.google.com/maps/d/kml?mid={st.session_state.map_id}&forcekml=1")
-        st.link_button(label="Edit in MyMaps", type="primary", url=f"https://www.google.com/maps/d/u/0/edit?mid={st.session_state.map_id}")
+        st.selectbox(
+            label=":world_map: **:blue[Load Map]**",
+            options=st.session_state.file_list.keys(),
+            format_func=lambda option: st.session_state.file_list[option],
+            key="map_id",
+            placeholder="Select a map to load from MyMaps...",
+        )
+        components.iframe(
+            f"https://www.google.com/maps/d/u/0/embed?mid={st.session_state.map_id}",
+            height=600,
+            scrolling=True,
+        )
+        st.link_button(
+            label="Download KML",
+            type="primary",
+            url=f"https://www.google.com/maps/d/kml?mid={st.session_state.map_id}&forcekml=1",
+        )
+        st.link_button(
+            label="Edit in MyMaps",
+            type="primary",
+            url=f"https://www.google.com/maps/d/u/0/edit?mid={st.session_state.map_id}",
+        )
 
 with c2:
     st.subheader(":clipboard: **:green[Edit Mission Script]**", divider="gray")
     dsl = st_ace(height=600, value=sample, language="yaml")
     st.download_button(
-        label="Download Mission File",
-        data=dsl,
-        file_name="mission.dsl",
-        type="primary"
+        label="Download Mission File", data=dsl, file_name="mission.dsl", type="primary"
     )
-

--- a/gcs/streamlit/util.py
+++ b/gcs/streamlit/util.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-import streamlit as st
-import redis
-import pandas as pd
-import json
-import zmq
-import time
 import hmac
+import json
+import time
+
+import pandas as pd
+import redis
+import streamlit as st
+import zmq
 
 DATA_TYPES = {
     "latitude": "float",

--- a/gcs/streamlit/util.py
+++ b/gcs/streamlit/util.py
@@ -44,9 +44,10 @@ COLORS = [
 if "control_pressed" not in st.session_state:
     st.session_state.control_pressed = False
 if "inactivity_time" not in st.session_state:
-    st.session_state.inactivity_time = 1 #min
+    st.session_state.inactivity_time = 1  # min
 if "password" not in st.session_state:
     st.session_state.password = ""
+
 
 def authenticated():
     """Returns `True` if the user had the correct password."""
@@ -64,13 +65,17 @@ def authenticated():
         return True
 
     # Show input for password.
-    a,b,c = st.columns(3)
+    a, b, c = st.columns(3)
     b.text_input(
-        "Password", type="password", on_change=password_entered, key="password",
+        "Password",
+        type="password",
+        on_change=password_entered,
+        key="password",
     )
     if "password_correct" in st.session_state:
         b.error("Authentication failed.", icon=":material/block:")
     return False
+
 
 @st.cache_resource
 def connect_redis():
@@ -83,6 +88,7 @@ def connect_redis():
     )
     return red
 
+
 @st.cache_resource
 def connect_redis_publisher():
     red = redis.Redis(
@@ -94,11 +100,12 @@ def connect_redis_publisher():
     subscriber = red.pubsub(ignore_subscribe_messages=True)
     return subscriber
 
+
 @st.cache_resource
 def connect_zmq():
     ctx = zmq.Context()
     z = ctx.socket(zmq.REQ)
-    z.connect(f'tcp://{st.secrets.zmq}:{st.secrets.zmq_port}')
+    z.connect(f"tcp://{st.secrets.zmq}:{st.secrets.zmq_port}")
     return z
 
 
@@ -107,7 +114,9 @@ def get_drones():
     red = connect_redis()
     for k in red.keys("drone:*"):
         last_seen = float(red.hget(k, "last_seen"))
-        if time.time() - last_seen <  st.session_state.inactivity_time * 60: # minutes -> seconds
+        if (
+            time.time() - last_seen < st.session_state.inactivity_time * 60
+        ):  # minutes -> seconds
             drone_name = k.split(":")[-1]
             drone_model = red.hget(k, "model")
             if drone_model == "":
@@ -116,12 +125,13 @@ def get_drones():
 
     return l
 
-def stream_to_dataframe(results, types=DATA_TYPES ) -> pd.DataFrame:
+
+def stream_to_dataframe(results, types=DATA_TYPES) -> pd.DataFrame:
     _container = {}
     for item in results:
         _container[item[0]] = json.loads(json.dumps(item[1]))
 
-    df = pd.DataFrame.from_dict(_container, orient='index')
+    df = pd.DataFrame.from_dict(_container, orient="index")
     if types is not None:
         try:
             df = df.astype(types)
@@ -129,6 +139,7 @@ def stream_to_dataframe(results, types=DATA_TYPES ) -> pd.DataFrame:
             print(e)
 
     return df
+
 
 def control_drone(drone):
     st.session_state.selected_drone = drone
@@ -139,6 +150,4 @@ def menu(with_control=True):
     st.sidebar.page_link("overview.py", label=":world_map: Tactical Overview")
     st.sidebar.page_link("pages/monitoring.py", label=":tv: Imagery and Telemetry")
     st.sidebar.page_link("pages/control.py", label=":joystick: Control")
-    #st.sidebar.page_link("pages/plan.py", label=":ledger: Mission Planning")
-
-
+    # st.sidebar.page_link("pages/plan.py", label=":ledger: Mission Planning")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,9 @@ nav:
   - Backend:
     - Design: backend/backend-design.md 
     - Setup: backend/backend-setup.md
+  - Supported Platforms:
+    - UAVs: platforms/uavs.md
+    - Companions: platforms/companions.md
 theme:
   name: material
   logo: assets/logo-color.png

--- a/protocol/dataplane.proto
+++ b/protocol/dataplane.proto
@@ -24,6 +24,7 @@ message Request {
     TelemetryRequest tel = 3;
     FrameRequest frame  = 4;
     GetComputeResult cpt = 5;
+    UpdateCurrentTask task = 6;
   }
 }
 
@@ -79,6 +80,10 @@ message Frame {
 */
 message GetComputeResult {
   string type = 1;
+}
+
+message UpdateCurrentTask {
+    string task_name = 1;
 }
 
 message ComputeResponse {

--- a/simulator/path_validator.py
+++ b/simulator/path_validator.py
@@ -127,7 +127,7 @@ class PathValidator:
         self.path_list.append(drone_path)
 
     def run_path(self, path: PathStore):
-        while path.is_path_complete() == False:
+        while not path.is_path_complete():
             path.move_next_waypoint()
 
     def replay_path(self, path: PathStore, start_point=0):
@@ -172,7 +172,7 @@ def render_test(path: PathStore):
     )
     path.set_current_waypoint(0)
     line_seg = []
-    while path.is_path_complete() == False:
+    while not path.is_path_complete():
         line_seg.append(
             draw_path(path.get_current_waypoint(), path.get_next_waypoint())
         )

--- a/simulator/path_validator.py
+++ b/simulator/path_validator.py
@@ -1,6 +1,5 @@
 import time
 import sys
-import os
 import logging
 import json
 import argparse

--- a/simulator/path_validator.py
+++ b/simulator/path_validator.py
@@ -85,7 +85,7 @@ class PathStore:
 
     def load_waypoints(self):
         # NOTE: Key names are 1-indexed in the compiler output waypoint file
-        with open(self.waypoint_file, "r") as file:
+        with open(self.waypoint_file) as file:
             data = json.load(file)
         self.total_legs = len(data[self.table_prefix])
         for i in range(self.total_legs):

--- a/simulator/path_validator.py
+++ b/simulator/path_validator.py
@@ -15,7 +15,8 @@ logger.setLevel(logging.DEBUG)
 DEFAULT_LAT = 40.41368353053923
 DEFAULT_LONG = -79.9489233699767
 
-class Coordinate():
+
+class Coordinate:
     def __init__(self, x, y, alt):
         self.long = x
         self.lat = y
@@ -23,14 +24,17 @@ class Coordinate():
 
     def to_tuple(self):
         return (self.lat, self.long)
-    
+
     def __sub__(self, other):
-        return Coordinate(self.long - other.long, self.lat - other.lat, self.alt - other.alt)
+        return Coordinate(
+            self.long - other.long, self.lat - other.lat, self.alt - other.alt
+        )
 
     def __repr__(self):
         return f"({self.long}, {self.lat}, {self.alt})"
 
-class PathStore():
+
+class PathStore:
     def __init__(self, filename, table_prefix, home):
         self.waypoint_file = filename
         self.table_prefix = table_prefix
@@ -45,11 +49,11 @@ class PathStore():
         self.name = name
 
     def set_current_waypoint(self, id):
-        if (id >= self.total_waypoints):
+        if id >= self.total_waypoints:
             logger.error("Set index out of path's waypoint bounds")
             return
         self.current_waypoint = id
-    
+
     def load_waypoints_from_leg(self, flight_leg):
         for waypoint in flight_leg:
             self.waypoints.append(waypoint)
@@ -61,44 +65,54 @@ class PathStore():
         else:
             del self.waypoints[id]
             logger.info(f"Removed waypoint id: {id}")
-    
+
     def get_current_waypoint(self):
         if self.current_waypoint >= self.total_waypoints:
-            logger.info(f"No waypoints remaining. Last waypoint id: {self.current_waypoint - 1}")
+            logger.info(
+                f"No waypoints remaining. Last waypoint id: {self.current_waypoint - 1}"
+            )
             return None
         return self.waypoints[self.current_waypoint]
 
     def get_next_waypoint(self):
         if self.current_waypoint >= self.total_waypoints - 1:
-            logger.info(f"No waypoints remaining. Last waypoint id: {self.current_waypoint - 1}")
+            logger.info(
+                f"No waypoints remaining. Last waypoint id: {self.current_waypoint - 1}"
+            )
             return None
         self.current_waypoint += 1
         return self.waypoints[self.current_waypoint]
-    
+
     def load_waypoints(self):
         # NOTE: Key names are 1-indexed in the compiler output waypoint file
-        with open(self.waypoint_file, 'r') as file:
+        with open(self.waypoint_file, "r") as file:
             data = json.load(file)
         self.total_legs = len(data[self.table_prefix])
         for i in range(self.total_legs):
-            flight_leg = value_to_coord_list(data[self.table_prefix][f"{self.table_prefix}_{i + 1}"])
+            flight_leg = value_to_coord_list(
+                data[self.table_prefix][f"{self.table_prefix}_{i + 1}"]
+            )
             self.load_waypoints_from_leg(flight_leg)
         # Assumes RTH after path completion
         self.waypoints.append(self.home)
         self.total_waypoints += 1
-    
+
     def is_path_complete(self):
         return self.current_waypoint + 1 == self.total_waypoints
-    
+
     def move_next_waypoint(self):
-        logger.info(f"Moving from id: {self.current_waypoint} to id: {self.current_waypoint + 1}")
+        logger.info(
+            f"Moving from id: {self.current_waypoint} to id: {self.current_waypoint + 1}"
+        )
         curr_waypoint = self.get_current_waypoint()
         next_waypoint = self.get_next_waypoint()
         logger.info(f"{curr_waypoint} ---> {next_waypoint}")
-        
 
-class PathValidator():
-    def __init__(self, waypoint_file, mission_file, table_prefix, drone_count, lat, long, alt):
+
+class PathValidator:
+    def __init__(
+        self, waypoint_file, mission_file, table_prefix, drone_count, lat, long, alt
+    ):
         self.path_list = []
         self.waypoint_file = waypoint_file
         self.mission_file = mission_file
@@ -106,7 +120,7 @@ class PathValidator():
         self.drone_count = drone_count
         self.home = Coordinate(long, lat, alt)
         self.tick_rate = 1
-    
+
     def parse_paths(self):
         drone_path = PathStore(self.waypoint_file, self.table_prefix, self.home)
         drone_path.load_waypoints()
@@ -117,7 +131,7 @@ class PathValidator():
             path.move_next_waypoint()
 
     def replay_path(self, path: PathStore, start_point=0):
-        if (start_point >= path.total_waypoints):
+        if start_point >= path.total_waypoints:
             logger.error("Replay index out of path's waypoint bounds")
             return
         path.set_current_waypoint(start_point)
@@ -125,70 +139,99 @@ class PathValidator():
 
     def set_simulation_speed(self, new_speed: float):
         if new_speed <= 0:
-            logger.error("Attempted to set simulation speed to invalid value." \
-            "Tick rate must be positive")
+            logger.error(
+                "Attempted to set simulation speed to invalid value."
+                "Tick rate must be positive"
+            )
             return
         self.tick_rate = new_speed
 
 
 # UTILITY FUNCTIONS #
 
+
 def value_to_coord_list(dict_value: list[Coordinate], alt: float = 0.0):
     coord_list = []
     for points in dict_value:
         # Assumes format is [Long, Lat, Alt]
-        if (len(points) == 3):
+        if len(points) == 3:
             coord_list.append(Coordinate(points[0], points[1], points[2]))
         else:
             coord_list.append(Coordinate(points[0], points[1], alt))
     return coord_list
 
+
 def calc_vector_to(start_pos: Coordinate, target_pos: Coordinate):
     return target_pos - start_pos
 
+
 def render_test(path: PathStore):
     st.title("Path Validator")
-    test_map = folium.Map(location=[40.4125, -79.9475], zoom_start=17, control_scale=True)
+    test_map = folium.Map(
+        location=[40.4125, -79.9475], zoom_start=17, control_scale=True
+    )
     path.set_current_waypoint(0)
     line_seg = []
     while path.is_path_complete() == False:
-        line_seg.append(draw_path(path.get_current_waypoint(), path.get_next_waypoint()))
+        line_seg.append(
+            draw_path(path.get_current_waypoint(), path.get_next_waypoint())
+        )
         for lines in line_seg:
             lines.add_to(test_map)
         st_data = st_folium(test_map, width=800)
-        time.sleep(.25)
+        time.sleep(0.25)
+
 
 def draw_path(curr_point: Coordinate, next_point: Coordinate):
     coords = [curr_point.to_tuple(), next_point.to_tuple()]
     return folium.PolyLine(locations=coords, weight=3, color="blue")
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        'waypoint_file', help='path to waypoint file being validated', type=str, default=""
+        "waypoint_file",
+        help="path to waypoint file being validated",
+        type=str,
+        default="",
     )
     parser.add_argument(
-        '-m', '--mission-file', help='path to mission file being validated', type=str, default=""
+        "-m",
+        "--mission-file",
+        help="path to mission file being validated",
+        type=str,
+        default="",
     )
     parser.add_argument(
-        '-d', '--drones', help='number of drones to simulate', type=int, default=1
+        "-d", "--drones", help="number of drones to simulate", type=int, default=1
     )
     parser.add_argument(
-        '--lat', help='origin point latitude', type=float, default=DEFAULT_LAT
+        "--lat", help="origin point latitude", type=float, default=DEFAULT_LAT
     )
     parser.add_argument(
-        '--long', help='origin point longitude', type=float, default=DEFAULT_LONG
+        "--long", help="origin point longitude", type=float, default=DEFAULT_LONG
     )
     parser.add_argument(
-        '-a', '--alt', help='origin point altitude', type=float, default=0.0
+        "-a", "--alt", help="origin point altitude", type=float, default=0.0
     )
     parser.add_argument(
-        '-p', '--table-prefix', help='prefix for the waypoint value keys in the waypoint file', type=str, default="Hex"
+        "-p",
+        "--table-prefix",
+        help="prefix for the waypoint value keys in the waypoint file",
+        type=str,
+        default="Hex",
     )
     args = parser.parse_args()
 
-    validator = PathValidator(args.waypoint_file, args.mission_file, args.table_prefix, 
-                               args.drones, args.lat, args.long, args.alt)
+    validator = PathValidator(
+        args.waypoint_file,
+        args.mission_file,
+        args.table_prefix,
+        args.drones,
+        args.lat,
+        args.long,
+        args.alt,
+    )
     validator.parse_paths()
     validator.run_path(validator.path_list[0])
 

--- a/simulator/path_validator.py
+++ b/simulator/path_validator.py
@@ -1,8 +1,9 @@
-import time
-import sys
-import logging
-import json
 import argparse
+import json
+import logging
+import sys
+import time
+
 import folium
 import streamlit as st
 from streamlit_folium import st_folium

--- a/vehicle/datasinks/ComputeItf.py
+++ b/vehicle/datasinks/ComputeItf.py
@@ -12,7 +12,6 @@ class ComputeInterface(ABC):
         self.compute_id = compute_id
         self.compute_status = self.ComputeStatus.IDLE
 
-
     @abstractmethod
     async def run(self):
         """Running the worker."""

--- a/vehicle/datasinks/VOXLCompute.py
+++ b/vehicle/datasinks/VOXLCompute.py
@@ -1,5 +1,5 @@
 # import asyncio
-# from cnc_protocol import cnc_pb2
+# import gabriel_extras_pb2 as gabriel_extras
 # import cv2
 # from enum import Enum
 # from kernel.computes.ComputeItf import ComputeInterface
@@ -70,7 +70,7 @@
 #         '''
 #         logger.info("VOXL compute is running")
 #         while self.is_running:
-#             frame_data = cnc_pb2.Frame()
+#             frame_data = gabriel_extras.Frame()
 #             frame_id = self.data_store.get_raw_data(frame_data)
 
 #             # Wait for a new frame

--- a/vehicle/datasinks/gabriel_compute.py
+++ b/vehicle/datasinks/gabriel_compute.py
@@ -1,17 +1,19 @@
 import asyncio
 import logging
 import time
-import cv2
-import numpy as np
-from gabriel_protocol import gabriel_pb2
-from gabriel_client.zeromq_client import ProducerWrapper, ZeroMQClient
-from gabriel_server import cognitive_engine
-from datasinks.ComputeItf import ComputeInterface
-from hub.data_store import DataStore
-import dataplane_pb2 as data_protocol
+
 import controlplane_pb2 as control_protocol
+import cv2
+import dataplane_pb2 as data_protocol
 import gabriel_extras_pb2 as gabriel_extras
+import numpy as np
+from gabriel_client.zeromq_client import ProducerWrapper, ZeroMQClient
+from gabriel_protocol import gabriel_pb2
+from gabriel_server import cognitive_engine
+from hub.data_store import DataStore
 from util.utils import query_config
+
+from datasinks.ComputeItf import ComputeInterface
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/datasinks/gabriel_compute.py
+++ b/vehicle/datasinks/gabriel_compute.py
@@ -17,30 +17,29 @@ from datasinks.ComputeItf import ComputeInterface
 
 logger = logging.getLogger(__name__)
 
+
 class GabrielCompute(ComputeInterface):
-    def __init__(self, compute_id, data_store:DataStore):
+    def __init__(self, compute_id, data_store: DataStore):
         super().__init__(compute_id)
 
-        self.drone_id = query_config('driver.id')
+        self.drone_id = query_config("driver.id")
 
         # remote computation parameters
-        self.set_params = {
-            "model": "coco",
-            "hsv_lower": None,
-            "hsv_upper": None
-        }
+        self.set_params = {"model": "coco", "hsv_lower": None, "hsv_upper": None}
 
         # Gabriel
-        self.server = query_config('hub.network.cloudlet.endpoint')
-        self.port = query_config('hub.network.cloudlet.hub_to_gabriel')
+        self.server = query_config("hub.network.cloudlet.endpoint")
+        self.port = query_config("hub.network.cloudlet.hub_to_gabriel")
 
-        logger.info(f'Gabriel compute: Gabriel server: {self.server}')
-        logger.info(f'Gabriel compute: Gabriel port: {self.port}')
+        logger.info(f"Gabriel compute: Gabriel server: {self.server}")
+        logger.info(f"Gabriel compute: Gabriel port: {self.port}")
         self.engine_results = {}
         self.drone_registered = False
         self.gabriel_client = ZeroMQClient(
-            self.server, self.port,
-            [self.get_telemetry_producer(), self.get_frame_producer()], self.process_results
+            self.server,
+            self.port,
+            [self.get_telemetry_producer(), self.get_frame_producer()],
+            self.process_results,
         )
 
         # data_store
@@ -51,12 +50,10 @@ class GabrielCompute(ComputeInterface):
         logger.info("Gabriel compute: launching Gabriel client")
         await self.gabriel_client.launch_async()
 
-
     def set(self, model, hsv_lower, hsv_upper):
         self.set_params["model"] = model
         self.set_params["hsv_lower"] = hsv_lower
         self.set_params["hsv_upper"] = hsv_upper
-
 
     def stop(self):
         """Stopping the worker."""
@@ -73,10 +70,12 @@ class GabrielCompute(ComputeInterface):
         if len(result_wrapper.results) != 1:
             return
 
-        response = cognitive_engine.unpack_extras(control_protocol.Response, result_wrapper)
+        response = cognitive_engine.unpack_extras(
+            control_protocol.Response, result_wrapper
+        )
         for result in result_wrapper.results:
             if result.payload_type == gabriel_pb2.PayloadType.TEXT:
-                payload = result.payload.decode('utf-8')
+                payload = result.payload.decode("utf-8")
                 try:
                     if len(payload) != 0:
                         # get engine id
@@ -85,14 +84,24 @@ class GabrielCompute(ComputeInterface):
                         # get timestamp
                         timestamp = time.time()
                         # update
-                        if compute_type == 'openscout_object':
-                            logger.info(f"Gabriel compute: {timestamp=}, {compute_type=}, {result=}")
-                        logger.debug(f"Gabriel compute: {timestamp=}, {compute_type=}, {result=}")
+                        if compute_type == "openscout_object":
+                            logger.info(
+                                f"Gabriel compute: {timestamp=}, {compute_type=}, {result=}"
+                            )
+                        logger.debug(
+                            f"Gabriel compute: {timestamp=}, {compute_type=}, {result=}"
+                        )
                         self.data_store.update_compute_result(
-                            self.compute_id, compute_type, payload,
-                            response.seq_num, timestamp)
+                            self.compute_id,
+                            compute_type,
+                            payload,
+                            response.seq_num,
+                            timestamp,
+                        )
                 except Exception as e:
-                    logger.error(f"Gabriel compute process_results: error processing result: {e}")
+                    logger.error(
+                        f"Gabriel compute process_results: error processing result: {e}"
+                    )
             else:
                 logger.debug(f"Got result type {result.payload_type}. Expected TEXT.")
 
@@ -111,7 +120,9 @@ class GabrielCompute(ComputeInterface):
                 if entry is None:
                     logger.debug("Waiting for new frame from driver, entry is none!")
                 else:
-                    logger.debug(f"Waiting for new frame from driver, {entry.timestamp} <= {self.frame_ts}")
+                    logger.debug(
+                        f"Waiting for new frame from driver, {entry.timestamp} <= {self.frame_ts}"
+                    )
                 await self.data_store.wait_for_new_data(type(frame_data))
                 entry = self.data_store.get_raw_data(frame_data)
             self.frame_ts = entry.timestamp
@@ -119,13 +130,24 @@ class GabrielCompute(ComputeInterface):
             tel_data = data_protocol.Telemetry()
             self.data_store.get_raw_data(tel_data)
             try:
-                if frame_data is not None and frame_data.data != b'' and tel_data is not None:
-                    logger.debug(f"New frame frame_id={frame_data.id} available from driver, tel_data={tel_data}")
+                if (
+                    frame_data is not None
+                    and frame_data.data != b""
+                    and tel_data is not None
+                ):
+                    logger.debug(
+                        f"New frame frame_id={frame_data.id} available from driver, tel_data={tel_data}"
+                    )
 
                     frame_bytes = frame_data.data
 
-                    nparr = np.frombuffer(frame_bytes, dtype = np.uint8)
-                    frame = cv2.imencode('.jpg', nparr.reshape(frame_data.height, frame_data.width, frame_data.channels))[1]
+                    nparr = np.frombuffer(frame_bytes, dtype=np.uint8)
+                    frame = cv2.imencode(
+                        ".jpg",
+                        nparr.reshape(
+                            frame_data.height, frame_data.width, frame_data.channels
+                        ),
+                    )[1]
                     input_frame.payload_type = gabriel_pb2.PayloadType.IMAGE
                     input_frame.payloads.append(frame.tobytes())
 
@@ -133,33 +155,52 @@ class GabrielCompute(ComputeInterface):
                     extras = gabriel_extras.Extras()
                     compute_command = extras.cpt_request
 
-                    if self.set_params['model'] is not None:
-                        compute_command.cpt.model = self.set_params['model']
-                    if self.set_params['hsv_lower'] is not None:
-                        compute_command.cpt.lower_bound.h = self.set_params['hsv_lower'][0]
-                        compute_command.cpt.lower_bound.s = self.set_params['hsv_lower'][1]
-                        compute_command.cpt.lower_bound.v = self.set_params['hsv_lower'][2]
-                    if self.set_params['hsv_upper'] is not None:
-                        compute_command.cpt.upper_bound.h = self.set_params['hsv_upper'][0]
-                        compute_command.cpt.upper_bound.s = self.set_params['hsv_upper'][1]
-                        compute_command.cpt.upper_bound.v = self.set_params['hsv_upper'][2]
+                    if self.set_params["model"] is not None:
+                        compute_command.cpt.model = self.set_params["model"]
+                    if self.set_params["hsv_lower"] is not None:
+                        compute_command.cpt.lower_bound.h = self.set_params[
+                            "hsv_lower"
+                        ][0]
+                        compute_command.cpt.lower_bound.s = self.set_params[
+                            "hsv_lower"
+                        ][1]
+                        compute_command.cpt.lower_bound.v = self.set_params[
+                            "hsv_lower"
+                        ][2]
+                    if self.set_params["hsv_upper"] is not None:
+                        compute_command.cpt.upper_bound.h = self.set_params[
+                            "hsv_upper"
+                        ][0]
+                        compute_command.cpt.upper_bound.s = self.set_params[
+                            "hsv_upper"
+                        ][1]
+                        compute_command.cpt.upper_bound.v = self.set_params[
+                            "hsv_upper"
+                        ][2]
 
                     self.data_store.get_raw_data(extras.telemetry)
 
                     if compute_command is not None:
                         input_frame.extras.Pack(extras)
                 else:
-                    logger.info('Gabriel compute Frame producer: frame is None')
+                    logger.info("Gabriel compute Frame producer: frame is None")
                     input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
-                    input_frame.payloads.append("Streaming not started, no frame to show.".encode('utf-8'))
+                    input_frame.payloads.append(
+                        "Streaming not started, no frame to show.".encode("utf-8")
+                    )
             except Exception as e:
                 input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
-                input_frame.payloads.append("Unable to produce a frame!".encode('utf-8'))
-                logger.info(f'Gabriel compute Frame producer: unable to produce a frame: {e}')
+                input_frame.payloads.append(
+                    "Unable to produce a frame!".encode("utf-8")
+                )
+                logger.info(
+                    f"Gabriel compute Frame producer: unable to produce a frame: {e}"
+                )
 
             logger.debug(f"Gabriel compute Frame producer: finished time {time.time()}")
             return input_frame
-        return ProducerWrapper(producer=producer, source_name='telemetry')
+
+        return ProducerWrapper(producer=producer, source_name="telemetry")
 
     def get_telemetry_producer(self):
         async def producer():
@@ -169,7 +210,7 @@ class GabrielCompute(ComputeInterface):
             logger.debug(f"tel producer: starting time {time.time()}")
             input_frame = gabriel_pb2.InputFrame()
             input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
-            input_frame.payloads.append('heartbeart'.encode('utf8'))
+            input_frame.payloads.append("heartbeart".encode("utf8"))
             tel_data = data_protocol.Telemetry()
             ret = self.data_store.get_raw_data(tel_data)
 
@@ -177,24 +218,32 @@ class GabrielCompute(ComputeInterface):
                 if ret is not None:
                     extras = gabriel_extras.Extras()
                     extras.telemetry.CopyFrom(tel_data)
-                    logger.debug(f"Gabriel compute telemetry producer: sending telemetry; drone_name={tel_data.drone_name}")
+                    logger.debug(
+                        f"Gabriel compute telemetry producer: sending telemetry; drone_name={tel_data.drone_name}"
+                    )
                     # Register when we start sending telemetry
                     if not self.drone_registered and len(tel_data.drone_name) > 0:
-                        logger.info("Gabriel compute telemetry producer: sending registration request to backend")
+                        logger.info(
+                            "Gabriel compute telemetry producer: sending registration request to backend"
+                        )
                         extras.registering = True
                         self.drone_registered = True
                         tel_data.uptime.FromSeconds(0)
                     else:
-                        logger.debug("Gabriel compute telemetry producer: sending telemetry")
+                        logger.debug(
+                            "Gabriel compute telemetry producer: sending telemetry"
+                        )
                         # Send telemetry
                         extras.registering = False
                     input_frame.extras.Pack(extras)
-                    logger.debug(f'Gabriel compute telemetry producer: sending Gabriel telemetry! content: {extras}')
+                    logger.debug(
+                        f"Gabriel compute telemetry producer: sending Gabriel telemetry! content: {extras}"
+                    )
                 else:
-                    logger.error('Telemetry unavailable')
+                    logger.error("Telemetry unavailable")
             except Exception as e:
-                logger.error(f'Gabriel compute telemetry producer: {e}')
+                logger.error(f"Gabriel compute telemetry producer: {e}")
             logger.debug(f"tel producer: finished time {time.time()}")
             return input_frame
 
-        return ProducerWrapper(producer=producer, source_name='telemetry')
+        return ProducerWrapper(producer=producer, source_name="telemetry")

--- a/vehicle/datasinks/gabriel_compute.py
+++ b/vehicle/datasinks/gabriel_compute.py
@@ -107,7 +107,7 @@ class GabrielCompute(ComputeInterface):
             # Wait for a new frame
             while entry is None or entry.timestamp <= self.frame_ts:
                 if entry is None:
-                    logger.debug(f"Waiting for new frame from driver, entry is none!")
+                    logger.debug("Waiting for new frame from driver, entry is none!")
                 else:
                     logger.debug(f"Waiting for new frame from driver, {entry.timestamp} <= {self.frame_ts}")
                 await self.data_store.wait_for_new_data(type(frame_data))

--- a/vehicle/datasinks/gabriel_compute.py
+++ b/vehicle/datasinks/gabriel_compute.py
@@ -186,13 +186,11 @@ class GabrielCompute(ComputeInterface):
                     logger.info("Gabriel compute Frame producer: frame is None")
                     input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
                     input_frame.payloads.append(
-                        "Streaming not started, no frame to show.".encode("utf-8")
+                        b"Streaming not started, no frame to show."
                     )
             except Exception as e:
                 input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
-                input_frame.payloads.append(
-                    "Unable to produce a frame!".encode("utf-8")
-                )
+                input_frame.payloads.append(b"Unable to produce a frame!")
                 logger.info(
                     f"Gabriel compute Frame producer: unable to produce a frame: {e}"
                 )
@@ -210,7 +208,7 @@ class GabrielCompute(ComputeInterface):
             logger.debug(f"tel producer: starting time {time.time()}")
             input_frame = gabriel_pb2.InputFrame()
             input_frame.payload_type = gabriel_pb2.PayloadType.TEXT
-            input_frame.payloads.append("heartbeart".encode("utf8"))
+            input_frame.payloads.append(b"heartbeart")
             tel_data = data_protocol.Telemetry()
             ret = self.data_store.get_raw_data(tel_data)
 

--- a/vehicle/drivers/multicopter/autopilots/ardupilot.py
+++ b/vehicle/drivers/multicopter/autopilots/ardupilot.py
@@ -13,15 +13,15 @@ from pymavlink import mavutil
 
 logger = logging.getLogger(__name__)
 
+
 class ArduPilotDrone(MAVLinkDrone):
-    
     class FlightMode(Enum):
-        LAND = 'LAND'
-        RTL = 'RTL'
-        LOITER = 'LOITER'
-        GUIDED = 'GUIDED'
-        ALT_HOLD = 'ALT_HOLD'
-        
+        LAND = "LAND"
+        RTL = "RTL"
+        LOITER = "LOITER"
+        GUIDED = "GUIDED"
+        ALT_HOLD = "ALT_HOLD"
+
     def __init__(self, drone_id):
         self.drone_id = drone_id
         self.vehicle = None
@@ -30,14 +30,15 @@ class ArduPilotDrone(MAVLinkDrone):
         self._listener_task = None
         self._rel_altitude = 3
 
-    '''Interface Methods'''
+    """Interface Methods"""
+
     async def take_off(self):
         if await self._switch_mode(MAVLinkDrone.FlightMode.GUIDED) == False:
             return common_protocol.ResponseStatus.FAILED
-        
+
         if await self._arm() == False:
             return common_protocol.ResponseStatus.FAILED
-        
+
         gps = self._get_global_position()
         rel_altitude = self._rel_altitude
         target_altitude = rel_altitude + gps["absolute_altitude"]
@@ -46,38 +47,42 @@ class ArduPilotDrone(MAVLinkDrone):
             self.vehicle.target_component,
             mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,
             0,
-            0, 0, 0, 0,
-            0, 0, rel_altitude
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            rel_altitude,
         )
-        
+
         result = await self._wait_for_condition(
             lambda: self._is_abs_altitude_reached(target_altitude),
             timeout=60,
-            interval=1
+            interval=1,
         )
-        
+
         if result:
             return common_protocol.ResponseStatus.COMPLETED
         else:
             return common_protocol.ResponseStatus.FAILED
-    
+
     async def hover(self):
         # TODO: Implement hover:
-            # issues: The hover command in the mavlink by setting velocity body to 0 will
-            # interupt any other flying command like land, takeoff, etc. This is due to
-            # streamlit continuously sending the hover command in a high frequency.
+        # issues: The hover command in the mavlink by setting velocity body to 0 will
+        # interupt any other flying command like land, takeoff, etc. This is due to
+        # streamlit continuously sending the hover command in a high frequency.
         return common_protocol.ResponseStatus.NOTSUPPORTED
-    
+
     async def set_global_position(self, location):
         lat = location.latitude
         lon = location.longitude
         alt = location.absolute_altitude
         heading = location.heading
-        
-        if not await \
-                self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
+
+        if not await self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
             return common_protocol.ResponseStatus.FAILED
-        
+
         # TODO: Check if absolute alt isn't set then use rel_alt instead!
         self.vehicle.mav.set_position_target_global_int_send(
             0,
@@ -88,22 +93,25 @@ class ArduPilotDrone(MAVLinkDrone):
             int(lat * 1e7),
             int(lon * 1e7),
             alt,
-            0, 0, 0,
-            0, 0, 0,
-            0, 0
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
         )
-        
+
         result = await self._wait_for_condition(
-            lambda: self._is_at_target(lat, lon),
-            timeout=60,
-            interval=1
+            lambda: self._is_at_target(lat, lon), timeout=60, interval=1
         )
-        
+
         await self.set_heading(location)
-        
-        if result:  
+
+        if result:
             return common_protocol.ResponseStatus.COMPLETED
-        else:  
+        else:
             return common_protocol.ResponseStatus.FAILED
 
     async def set_velocity_global(self, velocity_global):
@@ -112,51 +120,62 @@ class ArduPilotDrone(MAVLinkDrone):
         up_vel = velocity_global.up_vel
         angular_vel = velocity_global.angular_vel
 
-        if not await \
-                self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
+        if not await self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
             return common_protocol.ResponseStatus.FAILED
-        
+
         self.vehicle.mav.set_position_target_local_ned_send(
             0,
             self.vehicle.target_system,
             self.vehicle.target_component,
             mavutil.mavlink.MAV_FRAME_LOCAL_NED,
             0b010111000111,
-            0, 0, 0,
-            north_vel, east_vel, -up_vel,
-            0, 0, 0,
-            float('nan'), angular_vel
+            0,
+            0,
+            0,
+            north_vel,
+            east_vel,
+            -up_vel,
+            0,
+            0,
+            0,
+            float("nan"),
+            angular_vel,
         )
-        
+
         return common_protocol.ResponseStatus.COMPLETED
-    
+
     async def set_velocity_body(self, velocity_body):
         forward_vel = velocity_body.forward_vel
         right_vel = velocity_body.right_vel
         up_vel = velocity_body.up_vel
         angular_vel = velocity_body.angular_vel
 
-        if not await \
-                self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
+        if not await self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
             return common_protocol.ResponseStatus.FAILED
-        
+
         self.vehicle.mav.set_position_target_local_ned_send(
             0,
             self.vehicle.target_system,
             self.vehicle.target_component,
             mavutil.mavlink.MAV_FRAME_BODY_NED,
             0b010111000111,
-            0, 0, 0,
-            forward_vel, right_vel, -up_vel,
-            0, 0, 0,
-            float('nan'), angular_vel
+            0,
+            0,
+            0,
+            forward_vel,
+            right_vel,
+            -up_vel,
+            0,
+            0,
+            0,
+            float("nan"),
+            angular_vel,
         )
-        
+
         return common_protocol.ResponseStatus.COMPLETED
 
     async def set_heading(self, location):
-        if not await \
-            self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
+        if not await self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
             return common_protocol.ResponseStatus.FAILED
         lat = location.latitude
         lon = location.longitude
@@ -168,9 +187,9 @@ class ArduPilotDrone(MAVLinkDrone):
             current_lat = current_location["latitude"]
             current_lon = current_location["longitude"]
             heading = self._calculate_heading(current_lat, current_lon, lat, lon)
-        
-        yaw_speed=20
-        direction=0
+
+        yaw_speed = 20
+        direction = 0
         relative_flag = 0
         self.vehicle.mav.command_long_send(
             self.vehicle.target_system,
@@ -178,19 +197,19 @@ class ArduPilotDrone(MAVLinkDrone):
             mavutil.mavlink.MAV_CMD_CONDITION_YAW,
             0,  # Confirmation
             heading,  # param1: Yaw angle
-            yaw_speed,   # param2: Yaw speed in deg/s
-            direction,   # param3: -1=CCW, 1=CW, 0=fastest (only for absolute yaw)
+            yaw_speed,  # param2: Yaw speed in deg/s
+            direction,  # param3: -1=CCW, 1=CW, 0=fastest (only for absolute yaw)
             relative_flag,  # param4: 0=Absolute, 1=Relative
-            0, 0, 0  # param5, param6, param7 (Unused)
+            0,
+            0,
+            0,  # param5, param6, param7 (Unused)
         )
-        
-        result =  await self._wait_for_condition(
-            lambda: self._is_heading_reached(heading),
-            timeout=30,
-            interval=0.5
+
+        result = await self._wait_for_condition(
+            lambda: self._is_heading_reached(heading), timeout=30, interval=0.5
         )
-        
-        if  result:
+
+        if result:
             return common_protocol.ResponseStatus.COMPLETED
         else:
             return common_protocol.ResponseStatus.FAILED

--- a/vehicle/drivers/multicopter/autopilots/ardupilot.py
+++ b/vehicle/drivers/multicopter/autopilots/ardupilot.py
@@ -33,10 +33,10 @@ class ArduPilotDrone(MAVLinkDrone):
     """Interface Methods"""
 
     async def take_off(self):
-        if await self._switch_mode(MAVLinkDrone.FlightMode.GUIDED) == False:
+        if not await self._switch_mode(MAVLinkDrone.FlightMode.GUIDED):
             return common_protocol.ResponseStatus.FAILED
 
-        if await self._arm() == False:
+        if not await self._arm():
             return common_protocol.ResponseStatus.FAILED
 
         gps = self._get_global_position()

--- a/vehicle/drivers/multicopter/autopilots/ardupilot.py
+++ b/vehicle/drivers/multicopter/autopilots/ardupilot.py
@@ -1,9 +1,5 @@
 # General imports
 from enum import Enum
-import math
-import os
-import time
-import asyncio
 import logging
 # SDK import (MAVLink)
 from pymavlink import mavutil

--- a/vehicle/drivers/multicopter/autopilots/ardupilot.py
+++ b/vehicle/drivers/multicopter/autopilots/ardupilot.py
@@ -1,12 +1,15 @@
 # General imports
-from enum import Enum
 import logging
-# SDK import (MAVLink)
-from pymavlink import mavutil
-# Interface import
-from multicopter.autopilots.mavlink import MAVLinkDrone
+from enum import Enum
+
 # Protocol imports
 import common_pb2 as common_protocol
+
+# Interface import
+from multicopter.autopilots.mavlink import MAVLinkDrone
+
+# SDK import (MAVLink)
+from pymavlink import mavutil
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/drivers/multicopter/autopilots/mavlink.py
+++ b/vehicle/drivers/multicopter/autopilots/mavlink.py
@@ -1,7 +1,6 @@
 # General imports
 from enum import Enum
 import math
-import os
 import time
 import asyncio
 import logging

--- a/vehicle/drivers/multicopter/autopilots/mavlink.py
+++ b/vehicle/drivers/multicopter/autopilots/mavlink.py
@@ -1,16 +1,20 @@
 # General imports
-from enum import Enum
-import math
-import time
 import asyncio
 import logging
-# SDK import (MAVLink)
-from pymavlink import mavutil
-# Interface import
-from multicopter.multicopter_interface import MulticopterItf
+import math
+import time
+from enum import Enum
+
+import common_pb2 as common_protocol
+
 # Protocol imports
 import dataplane_pb2 as data_protocol
-import common_pb2 as common_protocol
+
+# Interface import
+from multicopter.multicopter_interface import MulticopterItf
+
+# SDK import (MAVLink)
+from pymavlink import mavutil
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/drivers/multicopter/autopilots/mavlink.py
+++ b/vehicle/drivers/multicopter/autopilots/mavlink.py
@@ -441,14 +441,14 @@ class MAVLinkDrone(MulticopterItf):
             return False
 
         mode_id = self._mode_mapping[mode_target]
-        if type(mode_id) == int:
+        if isinstance(mode_id, int):
             # ArduPilot has a single ID for each mode
             self.vehicle.mav.set_mode_send(
                 self.vehicle.target_system,
                 mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
                 mode_id,
             )
-        elif type(mode_id) == list or type(mode_id) == tuple:
+        elif isinstance(mode_id, list) or isinstance(mode_id, tuple):
             # PX4 has a three digit ID for each mode
             self.vehicle.mav.command_long_send(
                 self.vehicle.target_system,

--- a/vehicle/drivers/multicopter/autopilots/parrot_olympe.py
+++ b/vehicle/drivers/multicopter/autopilots/parrot_olympe.py
@@ -263,7 +263,7 @@ class ParrotOlympeDrone(MulticopterItf):
     async def set_heading(self, location):
         lat = location.latitude
         lon = location.longitude
-        bearing = location.bearing
+        bearing = location.heading
         heading_mode = location.heading_mode
 
         if heading_mode == common_protocol.LocationHeadingMode.HEADING_START:
@@ -273,7 +273,7 @@ class ParrotOlympeDrone(MulticopterItf):
             target = self._calculate_bearing(
                 global_position["latitude"], global_position["longitude"], lat, lon
             )
-        offset = math.radians(heading - target)
+        offset = math.radians(bearing - target)
 
         try:
             self._drone(moveBy(0.0, 0.0, 0.0, offset)).success()

--- a/vehicle/drivers/multicopter/autopilots/parrot_olympe.py
+++ b/vehicle/drivers/multicopter/autopilots/parrot_olympe.py
@@ -16,12 +16,11 @@ from olympe.messages.move import extended_move_to
 from olympe.messages.rth import set_custom_location, return_to_home, custom_location, state
 import olympe.enums.rth as rth_state
 from olympe.messages.common.CommonState import BatteryStateChanged
-from olympe.messages.ardrone3.SpeedSettingsState import MaxVerticalSpeedChanged, MaxRotationSpeedChanged
+from olympe.messages.ardrone3.SpeedSettingsState import MaxRotationSpeedChanged
 from olympe.messages.ardrone3.PilotingState import AttitudeChanged, GpsLocationChanged, AltitudeChanged, FlyingStateChanged, SpeedChanged, moveToChanged, moveByChanged
 from olympe.enums.ardrone3.PilotingState import FlyingStateChanged_State
 from olympe.messages.ardrone3.GPSState import NumberOfSatelliteChanged
 from olympe.messages.gimbal import set_target, attitude
-import olympe.enums.gimbal as gimbal_mode
 import olympe.enums.move as move_mode
 from olympe.messages.common.CalibrationState import MagnetoCalibrationRequiredState
 # Interface import
@@ -924,7 +923,7 @@ class FFMPEGStreamingThread(threading.Thread):
                 try:
                     ret, self._current_frame = self._cap.read()
                     if not ret:
-                        logger.error(f"No frame received from cap, restarting")
+                        logger.error("No frame received from cap, restarting")
                         self.is_running = False
                 except Exception as e:
                     logger.error(f"Frame could not be read, reason: {e}")

--- a/vehicle/drivers/multicopter/autopilots/parrot_olympe.py
+++ b/vehicle/drivers/multicopter/autopilots/parrot_olympe.py
@@ -1,36 +1,53 @@
 # General imports
-import math
-import time
 import asyncio
 import logging
-from enum import Enum
-import numpy as np
-import cv2
+import math
 import os
-# SDK imports (Olympe)
-import olympe
-from olympe import Drone
-from olympe.messages.ardrone3.Piloting import TakeOff, Landing
-from olympe.messages.ardrone3.Piloting import PCMD, moveTo, moveBy
-from olympe.messages.move import extended_move_to
-from olympe.messages.rth import set_custom_location, return_to_home, custom_location, state
-import olympe.enums.rth as rth_state
-from olympe.messages.common.CommonState import BatteryStateChanged
-from olympe.messages.ardrone3.SpeedSettingsState import MaxRotationSpeedChanged
-from olympe.messages.ardrone3.PilotingState import AttitudeChanged, GpsLocationChanged, AltitudeChanged, FlyingStateChanged, SpeedChanged, moveToChanged, moveByChanged
-from olympe.enums.ardrone3.PilotingState import FlyingStateChanged_State
-from olympe.messages.ardrone3.GPSState import NumberOfSatelliteChanged
-from olympe.messages.gimbal import set_target, attitude
-import olympe.enums.move as move_mode
-from olympe.messages.common.CalibrationState import MagnetoCalibrationRequiredState
-# Interface import
-from multicopter.multicopter_interface import MulticopterItf
-# Protocol imports
-import dataplane_pb2 as data_protocol
-import common_pb2 as common_protocol
+import queue
+
 # Streaming imports
 import threading
-import queue
+import time
+from enum import Enum
+
+import common_pb2 as common_protocol
+import cv2
+
+# Protocol imports
+import dataplane_pb2 as data_protocol
+import numpy as np
+
+# SDK imports (Olympe)
+import olympe
+import olympe.enums.move as move_mode
+import olympe.enums.rth as rth_state
+
+# Interface import
+from multicopter.multicopter_interface import MulticopterItf
+from olympe import Drone
+from olympe.enums.ardrone3.PilotingState import FlyingStateChanged_State
+from olympe.messages.ardrone3.GPSState import NumberOfSatelliteChanged
+from olympe.messages.ardrone3.Piloting import PCMD, Landing, TakeOff, moveBy, moveTo
+from olympe.messages.ardrone3.PilotingState import (
+    AltitudeChanged,
+    AttitudeChanged,
+    FlyingStateChanged,
+    GpsLocationChanged,
+    SpeedChanged,
+    moveByChanged,
+    moveToChanged,
+)
+from olympe.messages.ardrone3.SpeedSettingsState import MaxRotationSpeedChanged
+from olympe.messages.common.CalibrationState import MagnetoCalibrationRequiredState
+from olympe.messages.common.CommonState import BatteryStateChanged
+from olympe.messages.gimbal import attitude, set_target
+from olympe.messages.move import extended_move_to
+from olympe.messages.rth import (
+    custom_location,
+    return_to_home,
+    set_custom_location,
+    state,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/drivers/multicopter/autopilots/px4.py
+++ b/vehicle/drivers/multicopter/autopilots/px4.py
@@ -1,14 +1,17 @@
 # General imports
-from enum import Enum
-import math
 import asyncio
 import logging
-# SDK import (MAVLink)
-from pymavlink import mavutil
-# Interface import
-from multicopter.autopilots.mavlink import MAVLinkDrone
+import math
+from enum import Enum
+
 # Protocol imports
 import common_pb2 as common_protocol
+
+# Interface import
+from multicopter.autopilots.mavlink import MAVLinkDrone
+
+# SDK import (MAVLink)
+from pymavlink import mavutil
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/drivers/multicopter/autopilots/px4.py
+++ b/vehicle/drivers/multicopter/autopilots/px4.py
@@ -1,8 +1,6 @@
 # General imports
 from enum import Enum
 import math
-import os
-import time
 import asyncio
 import logging
 # SDK import (MAVLink)
@@ -10,7 +8,6 @@ from pymavlink import mavutil
 # Interface import
 from multicopter.autopilots.mavlink import MAVLinkDrone
 # Protocol imports
-import dataplane_pb2 as data_protocol
 import common_pb2 as common_protocol
 
 logger = logging.getLogger(__name__)

--- a/vehicle/drivers/multicopter/autopilots/px4.py
+++ b/vehicle/drivers/multicopter/autopilots/px4.py
@@ -15,22 +15,23 @@ from pymavlink import mavutil
 
 logger = logging.getLogger(__name__)
 
-class PX4Drone(MAVLinkDrone):
 
+class PX4Drone(MAVLinkDrone):
     class OffboardHeartbeatMode(Enum):
-        GLOBAL = 'GLOBAL'
-        RELATIVE_ENU = 'RELATIVE_ENU'
-        RELATIVE_BODY = 'RELATIVE_BODY'
-        VELOCITY_ENU = 'VELOCITY_ENU'
-        VELOCITY_BODY = 'VELOCITY_BODY'
-        
+        GLOBAL = "GLOBAL"
+        RELATIVE_ENU = "RELATIVE_ENU"
+        RELATIVE_BODY = "RELATIVE_BODY"
+        VELOCITY_ENU = "VELOCITY_ENU"
+        VELOCITY_BODY = "VELOCITY_BODY"
+
     def __init__(self, drone_id):
         super().__init__(drone_id)
         self.offboard_mode = PX4Drone.OffboardHeartbeatMode.VELOCITY_BODY
         self._setpoint = (0.0, 0.0, 0.0, 0.0)
         self._setpoint_task = None
 
-    ''' Interface methods '''
+    """ Interface methods """
+
     async def get_type(self):
         return "PX4 Drone"
 
@@ -42,74 +43,67 @@ class PX4Drone(MAVLinkDrone):
         heading = location.heading
 
         # TODO: Check if alt isn't set then use rel_alt instead
-       
+
         # Set heading to designated bearing
         await self.set_heading(location)
-        
+
         # Switch to offboard mode
         if not await self._switch_mode(MAVLinkDrone.FlightMode.OFFBOARD):
             logger.error("Failed to set mode to OFFBOARD")
             return common_protocol.ResponseStatus.FAILED
-        self.offboard_mode = \
-                PX4Drone.OffboardHeartbeatMode.GLOBAL
+        self.offboard_mode = PX4Drone.OffboardHeartbeatMode.GLOBAL
         if not self._setpoint_task:
-            self._setpoint_task = \
-                    asyncio.create_task(self._setpoint_heartbeat())
+            self._setpoint_task = asyncio.create_task(self._setpoint_heartbeat())
         self._setpoint = (lat, lon, alt, heading)
-    
+
         result = await self._wait_for_condition(
-            lambda: self._is_global_position_reached(lat, lon, alt),
-            interval=1
+            lambda: self._is_global_position_reached(lat, lon, alt), interval=1
         )
-        
+
         if result:
             return common_protocol.ResponseStatus.COMPLETED
         else:
             return common_protocol.ResponseStatus.FAILED
-    
+
     async def set_velocity_enu(self, velocity):
         north_vel = velocity.north_vel
         east_vel = velocity.east_vel
         up_vel = velocity.up_vel
         angular_vel = velocity.angular_vel
-        
+
         # Switch to offboard mode
         if not await self._switch_mode(MAVLinkDrone.FlightMode.OFFBOARD):
             logger.error("Failed to set mode to OFFBOARD")
             return common_protocol.ResponseStatus.FAILED
-        self.offboard_mode = \
-                PX4Drone.OffboardHeartbeatMode.VELOCITY_ENU
+        self.offboard_mode = PX4Drone.OffboardHeartbeatMode.VELOCITY_ENU
         if not self._setpoint_task:
-            self._setpoint_task = \
-                    asyncio.create_task(self._setpoint_heartbeat())
-        self._setpoint = (north_vel, east_vel, up_vel, angular_vel) 
-    
+            self._setpoint_task = asyncio.create_task(self._setpoint_heartbeat())
+        self._setpoint = (north_vel, east_vel, up_vel, angular_vel)
+
         return common_protocol.ResponseStatus.COMPLETED
-    
+
     async def set_velocity_body(self, velocity):
         forward_vel = velocity.forward_vel
         right_vel = velocity.right_vel
         up_vel = velocity.up_vel
         angular_vel = velocity.angular_vel
-        
+
         # Switch to offboard mode
         if not await self._switch_mode(MAVLinkDrone.FlightMode.OFFBOARD):
             logger.error("Failed to set mode to OFFBOARD")
             return common_protocol.ResponseStatus.FAILED
-        self.offboard_mode = \
-                PX4Drone.OffboardHeartbeatMode.VELOCITY_BODY
+        self.offboard_mode = PX4Drone.OffboardHeartbeatMode.VELOCITY_BODY
         if not self._setpoint_task:
-            self._setpoint_task = \
-                    asyncio.create_task(self._setpoint_heartbeat())
-        self._setpoint = (forward_vel, right_vel, up_vel, angular_vel) 
-    
+            self._setpoint_task = asyncio.create_task(self._setpoint_heartbeat())
+        self._setpoint = (forward_vel, right_vel, up_vel, angular_vel)
+
         return common_protocol.ResponseStatus.COMPLETED
 
     async def set_heading(self, location):
         lat = location.latitude
         lon = location.longitude
         heading = location.heading
-       
+
         # Calculate bearing if not provided
         current_location = self._get_global_position()
         current_lat = current_location["latitude"]
@@ -117,32 +111,30 @@ class PX4Drone(MAVLinkDrone):
         current_hdg = current_location["heading"]
         if heading is None:
             heading = self._calculate_bearing(current_lat, current_lon, lat, lon)
-            
-        yaw_speed = 25 # Degrees/s
+
+        yaw_speed = 25  # Degrees/s
 
         # Switch to offboard mode
         if not await self._switch_mode(MAVLinkDrone.FlightMode.OFFBOARD):
             logger.error("Failed to set mode to OFFBOARD")
             return common_protocol.ResponseStatus.FAILED
-        self.offboard_mode = \
-                PX4Drone.OffboardHeartbeatMode.VELOCITY_BODY
+        self.offboard_mode = PX4Drone.OffboardHeartbeatMode.VELOCITY_BODY
         if not self._setpoint_task:
-            self._setpoint_task = \
-                    asyncio.create_task(self._setpoint_heartbeat())
+            self._setpoint_task = asyncio.create_task(self._setpoint_heartbeat())
         direction = 1 if (heading - current_hdg + 540) % 360 - 180 >= 0 else -1
-        self._setpoint = (0.0, 0.0, 0.0, direction * yaw_speed) 
-        
-        result =  await self._wait_for_condition(
-            lambda: self._is_heading_reached(heading),
-            interval=0.2
+        self._setpoint = (0.0, 0.0, 0.0, direction * yaw_speed)
+
+        result = await self._wait_for_condition(
+            lambda: self._is_heading_reached(heading), interval=0.2
         )
-        
-        if  result:
+
+        if result:
             return common_protocol.ResponseStatus.COMPLETED
         else:
             return common_protocol.ResponseStatus.FAILED
 
-    ''' Coroutine methods '''
+    """ Coroutine methods """
+
     async def _setpoint_heartbeat(self):
         # Send frequent setpoints to keep the drone in OFFBOARD mode
         while True:
@@ -153,10 +145,17 @@ class PX4Drone(MAVLinkDrone):
                     self.vehicle.target_component,
                     mavutil.mavlink.MAV_FRAME_LOCAL_NED,
                     0b010111000111,
-                    0, 0, 0,
-                    self._setpoint[0], self._setpoint[1], -self._setpoint[2],
-                    0, 0, 0,
-                    0, math.radians(self._setpoint[3]) # Radians/s
+                    0,
+                    0,
+                    0,
+                    self._setpoint[0],
+                    self._setpoint[1],
+                    -self._setpoint[2],
+                    0,
+                    0,
+                    0,
+                    0,
+                    math.radians(self._setpoint[3]),  # Radians/s
                 )
             elif self.offboard_mode == PX4Drone.OffboardHeartbeatMode.VELOCITY_BODY:
                 self.vehicle.mav.set_position_target_local_ned_send(
@@ -165,10 +164,17 @@ class PX4Drone(MAVLinkDrone):
                     self.vehicle.target_component,
                     mavutil.mavlink.MAV_FRAME_BODY_NED,
                     0b010111000111,
-                    0, 0, 0,
-                    self._setpoint[0], self._setpoint[1], -self._setpoint[2],
-                    0, 0, 0,
-                    0, math.radians(self._setpoint[3]) # Radians/s
+                    0,
+                    0,
+                    0,
+                    self._setpoint[0],
+                    self._setpoint[1],
+                    -self._setpoint[2],
+                    0,
+                    0,
+                    0,
+                    0,
+                    math.radians(self._setpoint[3]),  # Radians/s
                 )
             elif self.offboard_mode == PX4Drone.OffboardHeartbeatMode.GLOBAL:
                 self.vehicle.mav.set_position_target_global_int_send(
@@ -180,9 +186,14 @@ class PX4Drone(MAVLinkDrone):
                     int(self._setpoint[0] * 1e7),
                     int(self._setpoint[1] * 1e7),
                     self._setpoint[2],
-                    0, 0, 0,
-                    0, 0, 0,
-                    0, 0
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
                 )
 
             await asyncio.sleep(0.05)

--- a/vehicle/drivers/multicopter/devices/ModalAI/Seeker/Seeker.py
+++ b/vehicle/drivers/multicopter/devices/ModalAI/Seeker/Seeker.py
@@ -3,7 +3,7 @@ from multicopter.autopilots.px4 import PX4Drone
 
 
 class Seeker(PX4Drone):
+    """Interface methods"""
 
-    ''' Interface methods '''
     async def get_type(self):
         return "ModalAI Seeker"

--- a/vehicle/drivers/multicopter/devices/ModalAI/Seeker/Seeker.py
+++ b/vehicle/drivers/multicopter/devices/ModalAI/Seeker/Seeker.py
@@ -1,6 +1,7 @@
 # Interface import
 from multicopter.autopilots.px4 import PX4Drone
 
+
 class Seeker(PX4Drone):
 
     ''' Interface methods '''

--- a/vehicle/drivers/multicopter/devices/ModalAI/Starling2Max/Starling2Max.py
+++ b/vehicle/drivers/multicopter/devices/ModalAI/Starling2Max/Starling2Max.py
@@ -3,7 +3,7 @@ from multicopter.autopilots.px4 import PX4Drone
 
 
 class Starling2Max(PX4Drone):
+    """Interface methods"""
 
-    ''' Interface methods '''
     async def get_type(self):
         return "ModalAI Starling 2 Max"

--- a/vehicle/drivers/multicopter/devices/ModalAI/Starling2Max/Starling2Max.py
+++ b/vehicle/drivers/multicopter/devices/ModalAI/Starling2Max/Starling2Max.py
@@ -1,6 +1,7 @@
 # Interface import
 from multicopter.autopilots.px4 import PX4Drone
 
+
 class Starling2Max(PX4Drone):
 
     ''' Interface methods '''

--- a/vehicle/drivers/multicopter/devices/Parrot/Anafi/Anafi.py
+++ b/vehicle/drivers/multicopter/devices/Parrot/Anafi/Anafi.py
@@ -6,24 +6,46 @@ from olympe.messages.gimbal import attitude
 
 
 class Anafi(ParrotOlympeDrone):
-
     def __init__(self, drone_id, **kwargs):
         super().__init__(drone_id, **kwargs)
-        self._forward_pid_values = {"Kp": 0.3, "Kd": 10.0, "Ki": 0.001, "PrevI": 0.0, "MaxI": 10.0}
-        self._right_pid_values = {"Kp": 0.3, "Kd": 10.0, "Ki": 0.001, "PrevI": 0.0, "MaxI": 10.0}
-        self._up_pid_values = {"Kp": 2.0, "Kd": 10.0, "Ki": 0.0, "PrevI": 0.0, "MaxI": 10.0}
+        self._forward_pid_values = {
+            "Kp": 0.3,
+            "Kd": 10.0,
+            "Ki": 0.001,
+            "PrevI": 0.0,
+            "MaxI": 10.0,
+        }
+        self._right_pid_values = {
+            "Kp": 0.3,
+            "Kd": 10.0,
+            "Ki": 0.001,
+            "PrevI": 0.0,
+            "MaxI": 10.0,
+        }
+        self._up_pid_values = {
+            "Kp": 2.0,
+            "Kd": 10.0,
+            "Ki": 0.0,
+            "PrevI": 0.0,
+            "MaxI": 10.0,
+        }
 
-    ''' Interface methods '''
+    """ Interface methods """
+
     async def get_type(self):
         return "Parrot Anafi"
 
-    ''' ACK methods '''
+    """ ACK methods """
+
     def _is_gimbal_pose_reached(self, yaw, pitch, roll):
         # Only await on pitch/roll since the Anafi gimbal cannot yaw
-        if self._drone(attitude(
-            pitch_relative=pitch,
-            roll_relative=roll,
-            _policy="check",
-            _float_tol=(1e-3, 1e-1))):
+        if self._drone(
+            attitude(
+                pitch_relative=pitch,
+                roll_relative=roll,
+                _policy="check",
+                _float_tol=(1e-3, 1e-1),
+            )
+        ):
             return True
         return False

--- a/vehicle/drivers/multicopter/devices/Parrot/Anafi/Anafi.py
+++ b/vehicle/drivers/multicopter/devices/Parrot/Anafi/Anafi.py
@@ -1,7 +1,9 @@
 # Interface import
 from multicopter.autopilots.parrot_olympe import ParrotOlympeDrone
+
 # Olympe SDK import
 from olympe.messages.gimbal import attitude
+
 
 class Anafi(ParrotOlympeDrone):
 

--- a/vehicle/drivers/multicopter/devices/SkyRocket/SkyViperV2450GPS/SkyViperV2450GPS.py
+++ b/vehicle/drivers/multicopter/devices/SkyRocket/SkyViperV2450GPS/SkyViperV2450GPS.py
@@ -5,6 +5,9 @@ from multicopter.autopilots.ardupilot import ArduPilotDrone
 # Protocol imports
 import dataplane_pb2 as data_protocol
 import asyncio
+# Streaming imports
+import cv2
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -63,11 +66,6 @@ class SkyViperV2450GPS(ArduPilotDrone):
     def _stop_streaming(self):
         self._streaming_thread.stop()
         
-# Streaming imports
-import cv2
-import numpy as np
-import os
-import threading
 
 class StreamingThread(threading.Thread):
 
@@ -95,7 +93,7 @@ class StreamingThread(threading.Thread):
         try:
             frame = self._current_frame.copy()
             return frame
-        except Exception as e:
+        except Exception:
             # Send a blank frame
             return None
 

--- a/vehicle/drivers/multicopter/devices/SkyRocket/SkyViperV2450GPS/SkyViperV2450GPS.py
+++ b/vehicle/drivers/multicopter/devices/SkyRocket/SkyViperV2450GPS/SkyViperV2450GPS.py
@@ -1,13 +1,16 @@
 # General import
-import logging
-# Interface import
-from multicopter.autopilots.ardupilot import ArduPilotDrone
-# Protocol imports
-import dataplane_pb2 as data_protocol
 import asyncio
+import logging
+import threading
+
 # Streaming imports
 import cv2
-import threading
+
+# Protocol imports
+import dataplane_pb2 as data_protocol
+
+# Interface import
+from multicopter.autopilots.ardupilot import ArduPilotDrone
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/drivers/multicopter/devices/SkyRocket/SkyViperV2450GPS/SkyViperV2450GPS.py
+++ b/vehicle/drivers/multicopter/devices/SkyRocket/SkyViperV2450GPS/SkyViperV2450GPS.py
@@ -14,30 +14,31 @@ from multicopter.autopilots.ardupilot import ArduPilotDrone
 
 logger = logging.getLogger(__name__)
 
+
 class SkyViperV2450GPS(ArduPilotDrone):
-    
     def __init__(self, drone_id, **drone_args):
         super().__init__(drone_id)
         self._streaming_thread = None
-        self.url = drone_args.get('video_url', None)
-        
-    ''' Interface Methods '''
+        self.url = drone_args.get("video_url", None)
+
+    """ Interface Methods """
+
     async def get_type(self):
         return "SkyRocket SkyViper v2450 GPS"
 
     async def stream_video(self, cam_sock, rate_hz):
-        logger.info('Starting camera stream')
+        logger.info("Starting camera stream")
         self._start_streaming(self.url)
         frame_id = 0
         while await self.is_connected():
             try:
                 cam_message = data_protocol.Frame()
                 frame, frame_shape = await self._get_video_frame()
-                
+
                 if frame is None:
-                    logger.error('Failed to get video frame')
+                    logger.error("Failed to get video frame")
                     continue
-                
+
                 cam_message.data = frame
                 cam_message.height = frame_shape[0]
                 cam_message.width = frame_shape[1]
@@ -46,17 +47,16 @@ class SkyViperV2450GPS(ArduPilotDrone):
                 cam_sock.send(cam_message.SerializeToString())
                 frame_id = frame_id + 1
             except Exception as e:
-                logger.error(f'Failed to get video frame, error: {e}')
+                logger.error(f"Failed to get video frame, error: {e}")
             await asyncio.sleep(1 / rate_hz)
         self._stop_streaming()
         logger.info("Camera stream ended, disconnected from drone")
-    
-    
+
     async def set_gimbal_pose(self, pose):
         pass
-    
-    
-    ''' Stream methods '''
+
+    """ Stream methods """
+
     def _start_streaming(self, url):
         if not self._streaming_thread:
             self._streaming_thread = StreamingThread(url)
@@ -64,14 +64,16 @@ class SkyViperV2450GPS(ArduPilotDrone):
 
     async def _get_video_frame(self):
         if self._streaming_thread.is_running:
-            return [self._streaming_thread.grab_frame().tobytes(), self._streaming_thread.get_frame_shape()]
+            return [
+                self._streaming_thread.grab_frame().tobytes(),
+                self._streaming_thread.get_frame_shape(),
+            ]
 
     def _stop_streaming(self):
         self._streaming_thread.stop()
-        
+
 
 class StreamingThread(threading.Thread):
-
     def __init__(self, url):
         threading.Thread.__init__(self)
         self._current_frame = None
@@ -84,14 +86,14 @@ class StreamingThread(threading.Thread):
 
     def run(self):
         try:
-            while(self.is_running):
+            while self.is_running:
                 ret, self._current_frame = self.cap.read()
         except Exception as e:
             logger.error(e)
-            
+
     def get_frame_shape(self):
         return self._current_frame.shape
-    
+
     def grab_frame(self):
         try:
             frame = self._current_frame.copy()

--- a/vehicle/drivers/multicopter/driver.py
+++ b/vehicle/drivers/multicopter/driver.py
@@ -129,10 +129,6 @@ class Driver:
                 logger.info("****** Set Position ENU ******")
                 # TODO: Implement this
                 logger.error("Not implemented yet!")
-            elif vehicle_control == "position_enu":
-                logger.info("****** Set Position ENU ******")
-                # TODO: Implement this
-                logger.error("Not implemented yet!")
             elif vehicle_control == "velocity_enu":
                 logger.info("****** Set Velocity ENU ******")
                 logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
@@ -170,7 +166,7 @@ def get_drone(drone_id, drone_args, drone_module):
         drone = getattr(drone_obj, drone_name)(drone_id, **drone_args)
         return drone
     except Exception as e:
-        raise Exception(f"Could not initialize drone, reason: {e}")
+        raise Exception(f"Could not initialize drone, reason: {e}") from e
 
 
 if __name__ == "__main__":

--- a/vehicle/drivers/multicopter/driver.py
+++ b/vehicle/drivers/multicopter/driver.py
@@ -30,7 +30,11 @@ class Driver:
         while True:
             try:
                 logger.info('Attempting to connect to drone...')
-                await self.drone.connect(connection_string)
+                connected = await self.drone.connect(connection_string)
+                if not connected:
+                    logger.error('Failed to connect to drone, retrying...')
+                    await asyncio.sleep(3)
+                    continue
                 logger.info('Drone connected')
             except Exception:
                 logger.error('Failed to connect to drone, retrying...')

--- a/vehicle/drivers/multicopter/driver.py
+++ b/vehicle/drivers/multicopter/driver.py
@@ -11,6 +11,7 @@ from util.utils import SocketOperation, query_config, setup_logging, setup_socke
 
 logger = logging.getLogger(__name__)
 
+
 class Driver:
     def __init__(self, drone):
         self.drone = drone
@@ -22,48 +23,62 @@ class Driver:
         self.tel_sock.setsockopt(zmq.CONFLATE, 1)
         self.cam_sock.setsockopt(zmq.CONFLATE, 1)
 
-        setup_socket(self.tel_sock, SocketOperation.CONNECT, 'hub.network.dataplane.driver_to_hub.telemetry')
-        setup_socket(self.cam_sock, SocketOperation.CONNECT, 'hub.network.dataplane.driver_to_hub.image_sensor')
-        setup_socket(self.hub_to_driver_sock, SocketOperation.CONNECT, 'hub.network.controlplane.hub_to_driver')
+        setup_socket(
+            self.tel_sock,
+            SocketOperation.CONNECT,
+            "hub.network.dataplane.driver_to_hub.telemetry",
+        )
+        setup_socket(
+            self.cam_sock,
+            SocketOperation.CONNECT,
+            "hub.network.dataplane.driver_to_hub.image_sensor",
+        )
+        setup_socket(
+            self.hub_to_driver_sock,
+            SocketOperation.CONNECT,
+            "hub.network.controlplane.hub_to_driver",
+        )
 
     async def run(self):
-        setup_logging(logger, 'driver.logging')
+        setup_logging(logger, "driver.logging")
         while True:
             try:
-                logger.info('Attempting to connect to drone...')
+                logger.info("Attempting to connect to drone...")
                 connected = await self.drone.connect(connection_string)
                 if not connected:
-                    logger.error('Failed to connect to drone, retrying...')
+                    logger.error("Failed to connect to drone, retrying...")
                     await asyncio.sleep(3)
                     continue
-                logger.info('Drone connected')
+                logger.info("Drone connected")
             except Exception:
-                logger.error('Failed to connect to drone, retrying...')
+                logger.error("Failed to connect to drone, retrying...")
                 await asyncio.sleep(3)
                 continue
 
-            logger.info('Established connection to drone, ready to receive commands!')
+            logger.info("Established connection to drone, ready to receive commands!")
 
-            logger.info('Started streaming telemetry and video')
+            logger.info("Started streaming telemetry and video")
             asyncio.create_task(self.drone.stream_video(self.cam_sock, 5))
             asyncio.create_task(self.drone.stream_telemetry(self.tel_sock, 5))
 
             while await self.drone.is_connected():
                 try:
                     message_parts = await self.hub_to_driver_sock.recv_multipart()
-                    logger.info('Received message!')
+                    logger.info("Received message!")
                     identity = message_parts[0]
-                    logger.info(f'Identity: {identity}')
+                    logger.info(f"Identity: {identity}")
                     data = message_parts[1]
-                    logger.info(f'Data: {data}')
+                    logger.info(f"Data: {data}")
                     message = control_protocol.Request()
                     message.ParseFromString(data)
-                    logger.info(f'Message: {message}')
-                    asyncio.create_task(self.handle(identity, message, self.hub_to_driver_sock))
+                    logger.info(f"Message: {message}")
+                    asyncio.create_task(
+                        self.handle(identity, message, self.hub_to_driver_sock)
+                    )
                 except Exception as e:
-                    logger.error(f'Command received error: {e}')
+                    logger.error(f"Command received error: {e}")
 
-            logger.info('Disconnected from drone')
+            logger.info("Disconnected from drone")
 
     async def handle(self, identity, message, resp_sock):
         if not message.HasField("veh"):
@@ -80,64 +95,64 @@ class Driver:
             if vehicle_control == "action":
                 action = message.veh.action
                 if action == control_protocol.VehicleAction.TAKEOFF:
-                    logger.info('****** Takeoff ******')
+                    logger.info("****** Takeoff ******")
                     logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
-                    result  = await self.drone.take_off()
+                    result = await self.drone.take_off()
                     logger.info(f"Call finished at: {time.time()}")
                 elif action == control_protocol.VehicleAction.LAND:
-                    logger.info('****** Land ******')
+                    logger.info("****** Land ******")
                     logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
-                    result  = await self.drone.land()
+                    result = await self.drone.land()
                     logger.info(f"Call finished at: {time.time()}")
                 elif action == control_protocol.VehicleAction.RTH:
-                    logger.info('****** Return to Home ******')
+                    logger.info("****** Return to Home ******")
                     logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
-                    result  = await self.drone.rth()
+                    result = await self.drone.rth()
                     logger.info(f"Call finished at: {time.time()}")
                 elif action == control_protocol.VehicleAction.HOVER:
-                    logger.info('****** Hover ******')
+                    logger.info("****** Hover ******")
                     logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
                     result = await self.drone.hover()
                     logger.info(f"Call finished at: {time.time()}")
                 elif action == control_protocol.VehicleAction.KILL:
-                    logger.info('****** Emergency Kill ******')
+                    logger.info("****** Emergency Kill ******")
                     logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
                     result = await self.drone.kill()
                     logger.info(f"Call finished at: {time.time()}")
             elif vehicle_control == "location":
-                logger.info('****** Set Global Position ******')
+                logger.info("****** Set Global Position ******")
                 logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
                 location = message.veh.location
                 result = await self.drone.set_global_position(location)
                 logger.info(f"Call finished at: {time.time()}")
             elif vehicle_control == "position_enu":
-                logger.info('****** Set Position ENU ******')
+                logger.info("****** Set Position ENU ******")
                 # TODO: Implement this
-                logger.error('Not implemented yet!')
+                logger.error("Not implemented yet!")
             elif vehicle_control == "position_enu":
-                logger.info('****** Set Position ENU ******')
+                logger.info("****** Set Position ENU ******")
                 # TODO: Implement this
-                logger.error('Not implemented yet!')
+                logger.error("Not implemented yet!")
             elif vehicle_control == "velocity_enu":
-                logger.info('****** Set Velocity ENU ******')
+                logger.info("****** Set Velocity ENU ******")
                 logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
                 velocity = message.veh.velocity_enu
                 result = await self.drone.set_velocity_enu(velocity)
                 logger.info(f"Call finished at: {time.time()}")
             elif vehicle_control == "velocity_body":
-                logger.info('****** Set Velocity Body ******')
+                logger.info("****** Set Velocity Body ******")
                 logger.info(f"Call started at: {time.time()}, seq id {seq_num}")
                 velocity = message.veh.velocity_body
                 result = await self.drone.set_velocity_body(velocity)
                 logger.info(f"Call finished at: {time.time()}")
             elif vehicle_control == "gimbal_pose":
-                logger.info('****** Set Gimbal Pose ******')
+                logger.info("****** Set Gimbal Pose ******")
                 pose = message.veh.gimbal_pose
                 result = await self.drone.set_gimbal_pose(pose)
             else:
                 raise Exception(f"Command type {vehicle_control} is not supported!")
         except Exception as e:
-            logger.error(f'Failed to handle command, error: {e}')
+            logger.error(f"Failed to handle command, error: {e}")
             result = common_protocol.ResponseStatus.FAILED
 
         # resp.timestamp = Timestamp()
@@ -146,9 +161,10 @@ class Driver:
         logger.info("Sending back message")
         resp_sock.send_multipart([identity, resp.SerializeToString()])
 
+
 def get_drone(drone_id, drone_args, drone_module):
     try:
-        drone_name = drone_module.split('.')[-1]
+        drone_name = drone_module.split(".")[-1]
         drone_import = f"multicopter.{drone_module}.{drone_name}"
         drone_obj = importlib.import_module(drone_import)
         drone = getattr(drone_obj, drone_name)(drone_id, **drone_args)
@@ -156,13 +172,14 @@ def get_drone(drone_id, drone_args, drone_module):
     except Exception as e:
         raise Exception(f"Could not initialize drone, reason: {e}")
 
-if __name__ == "__main__":
-    setup_logging(logger, 'driver.logging')
 
-    drone_id = query_config('driver.id')
-    drone_module = query_config('driver.module')
-    drone_args = query_config('driver.keyword_args')
-    connection_string = query_config('driver.connection_string')
+if __name__ == "__main__":
+    setup_logging(logger, "driver.logging")
+
+    drone_id = query_config("driver.id")
+    drone_module = query_config("driver.module")
+    drone_args = query_config("driver.keyword_args")
+    connection_string = query_config("driver.connection_string")
 
     logger.info(f"Drone ID: {drone_id}")
     logger.info(f"Drone type: {drone_module}")

--- a/vehicle/drivers/multicopter/driver.py
+++ b/vehicle/drivers/multicopter/driver.py
@@ -1,12 +1,13 @@
-import time
-import zmq
-import zmq.asyncio
 import asyncio
 import importlib
 import logging
-import controlplane_pb2 as control_protocol
+import time
+
 import common_pb2 as common_protocol
-from util.utils import setup_socket, query_config, setup_logging, SocketOperation
+import controlplane_pb2 as control_protocol
+import zmq
+import zmq.asyncio
+from util.utils import SocketOperation, query_config, setup_logging, setup_socket
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/drivers/multicopter/multicopter_interface.py
+++ b/vehicle/drivers/multicopter/multicopter_interface.py
@@ -1,10 +1,13 @@
 # General imports
 from abc import ABC, abstractmethod
+
 # Protocol imports
 import common_pb2 as common_protocol
+
 # ZeroMQ binding imports
 import zmq
 import zmq.asyncio
+
 
 class MulticopterItf(ABC):
     """

--- a/vehicle/drivers/multicopter/multicopter_interface.py
+++ b/vehicle/drivers/multicopter/multicopter_interface.py
@@ -78,13 +78,13 @@ class MulticopterItf(ABC):
 
     @abstractmethod
     async def hover(self) -> common_protocol.ResponseStatus:
-       """
-       Instructs the drone to hover in place.
+        """
+        Instructs the drone to hover in place.
 
-       :return: A response object indicating success or failure
-       :rtype: :class:`protocol.common.ResponseStatus`
-       """
-       pass
+        :return: A response object indicating success or failure
+        :rtype: :class:`protocol.common.ResponseStatus`
+        """
+        pass
 
     @abstractmethod
     async def kill(self) -> common_protocol.ResponseStatus:
@@ -98,7 +98,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_home(self, loc: common_protocol.Location) -> common_protocol.ResponseStatus:
+    async def set_home(
+        self, loc: common_protocol.Location
+    ) -> common_protocol.ResponseStatus:
         """
         Sets the home global location destination (latitude, longitude, absolute or relative
         altitude in meters) for the drone. If an altitude is provided, the drone will attempt
@@ -124,7 +126,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_global_position(self, loc: common_protocol.Location) -> common_protocol.ResponseStatus:
+    async def set_global_position(
+        self, loc: common_protocol.Location
+    ) -> common_protocol.ResponseStatus:
         """
         Commands the drone to move to a specific global location (latitude, longitude,
         absolute or relative altitude in meters). If both absolute (MSL) and relative
@@ -145,8 +149,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_relative_position_enu(self, pos: common_protocol.PositionENU) \
-            -> common_protocol.ResponseStatus:
+    async def set_relative_position_enu(
+        self, pos: common_protocol.PositionENU
+    ) -> common_protocol.ResponseStatus:
         """
         Sets a target position for the drone relative to its initial (takeoff) point,
         in meters. The target position is expressed with respect to the ENU (east, north, up)
@@ -160,8 +165,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_relative_position_body(self, pos: common_protocol.PositionBody) \
-            -> common_protocol.ResponseStatus:
+    async def set_relative_position_body(
+        self, pos: common_protocol.PositionBody
+    ) -> common_protocol.ResponseStatus:
         """
         Sets a target position for the drone relative to its current position, in meters.
         The target position is expressed with respect to the FRU (forward, right, up)
@@ -175,7 +181,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_velocity_enu(self, vel: common_protocol.VelocityENU) -> common_protocol.ResponseStatus:
+    async def set_velocity_enu(
+        self, vel: common_protocol.VelocityENU
+    ) -> common_protocol.ResponseStatus:
         """
         Sets the drone's target velocity. The velocity target is expressed with respect to
         the ENU (east, north, up) global reference frame.
@@ -193,7 +201,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_velocity_body(self, vel: common_protocol.VelocityBody) -> common_protocol.ResponseStatus:
+    async def set_velocity_body(
+        self, vel: common_protocol.VelocityBody
+    ) -> common_protocol.ResponseStatus:
         """
         Sets the drone's target velocity. The velocity target is expressed with respect to
         the FRU (forward, right, up) body reference frame.
@@ -211,7 +221,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_heading(self, loc: common_protocol.Location) -> common_protocol.ResponseStatus:
+    async def set_heading(
+        self, loc: common_protocol.Location
+    ) -> common_protocol.ResponseStatus:
         """
         Sets the heading of the drone to face a provided global position (latitude, longitude)
         which is used to calculate a target bearing or an absolute heading (degrees).
@@ -229,7 +241,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def set_gimbal_pose(self, pose: common_protocol.PoseBody) -> common_protocol.ResponseStatus:
+    async def set_gimbal_pose(
+        self, pose: common_protocol.PoseBody
+    ) -> common_protocol.ResponseStatus:
         """
         Sets the gimbal pose of the drone, if it has a gimbal, with respect to the body frame
         of reference.
@@ -242,7 +256,9 @@ class MulticopterItf(ABC):
         pass
 
     @abstractmethod
-    async def stream_telemetry(self, tel_sock: zmq.asyncio.Socket, rate_hz: int) -> None:
+    async def stream_telemetry(
+        self, tel_sock: zmq.asyncio.Socket, rate_hz: int
+    ) -> None:
         """
         Continuously sends telemetry data from the drone to the provided ZeroMQ socket.
 

--- a/vehicle/drivers/multicopter/multicopter_interface.py
+++ b/vehicle/drivers/multicopter/multicopter_interface.py
@@ -1,6 +1,5 @@
 # General imports
 from abc import ABC, abstractmethod
-import asyncio
 # Protocol imports
 import common_pb2 as common_protocol
 # ZeroMQ binding imports

--- a/vehicle/drivers/multicopter/test/auto_test_suite.py
+++ b/vehicle/drivers/multicopter/test/auto_test_suite.py
@@ -20,17 +20,23 @@ logger = logging.getLogger(__name__)
 context = zmq.asyncio.Context()
 
 hub_to_driver_sock = context.socket(zmq.DEALER)
-setup_socket(hub_to_driver_sock, SocketOperation.BIND, 'hub.network.controlplane.hub_to_driver')
+setup_socket(
+    hub_to_driver_sock, SocketOperation.BIND, "hub.network.controlplane.hub_to_driver"
+)
 
 tel_sock = context.socket(zmq.SUB)
-tel_sock.setsockopt(zmq.SUBSCRIBE, b'') # Subscribe to all topics
+tel_sock.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics
 tel_sock.setsockopt(zmq.CONFLATE, 1)
-setup_socket(tel_sock, SocketOperation.BIND, 'hub.network.dataplane.driver_to_hub.telemetry')
+setup_socket(
+    tel_sock, SocketOperation.BIND, "hub.network.dataplane.driver_to_hub.telemetry"
+)
 
 cam_sock = context.socket(zmq.SUB)
-cam_sock.setsockopt(zmq.SUBSCRIBE, b'')  # Subscribe to all topics
+cam_sock.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics
 cam_sock.setsockopt(zmq.CONFLATE, 1)
-setup_socket(cam_sock, SocketOperation.BIND, 'hub.network.dataplane.driver_to_hub.image_sensor')
+setup_socket(
+    cam_sock, SocketOperation.BIND, "hub.network.dataplane.driver_to_hub.image_sensor"
+)
 
 tel_dict = {
     "name": "",
@@ -39,8 +45,9 @@ tel_dict = {
     "global_position": {},
     "relative_position": {},
     "velocity_body": {},
-    "gimbal_pose": {}
+    "gimbal_pose": {},
 }
+
 
 # Background telemetry receiver
 async def recv_telemetry():
@@ -52,25 +59,28 @@ async def recv_telemetry():
             msg = await tel_sock.recv()
             telemetry = data_protocol.Telemetry()
             telemetry.ParseFromString(msg)
-            tel_dict['name'] = telemetry.drone_name
-            tel_dict['battery'] = telemetry.battery
-            tel_dict['satellites'] = telemetry.satellites
-            tel_dict['global_position']['latitude'] = telemetry.global_position.latitude
-            tel_dict['global_position']['longitude'] = telemetry.global_position.longitude
-            tel_dict['global_position']['altitude'] = telemetry.global_position.altitude
-            tel_dict['global_position']['heading'] = telemetry.global_position.heading
-            tel_dict['relative_position']['up'] = telemetry.relative_position.up
-            tel_dict['velocity_body']['forward'] = telemetry.velocity_body.forward_vel
-            tel_dict['velocity_body']['right'] = telemetry.velocity_body.right_vel
-            tel_dict['velocity_body']['up'] = telemetry.velocity_body.up_vel
-            tel_dict['velocity_body']['angular'] = telemetry.velocity_body.angular_vel
-            tel_dict['gimbal_pose']['yaw'] = telemetry.gimbal_pose.yaw
-            tel_dict['gimbal_pose']['pitch'] = telemetry.gimbal_pose.pitch
-            tel_dict['gimbal_pose']['roll'] = telemetry.gimbal_pose.roll
+            tel_dict["name"] = telemetry.drone_name
+            tel_dict["battery"] = telemetry.battery
+            tel_dict["satellites"] = telemetry.satellites
+            tel_dict["global_position"]["latitude"] = telemetry.global_position.latitude
+            tel_dict["global_position"]["longitude"] = (
+                telemetry.global_position.longitude
+            )
+            tel_dict["global_position"]["altitude"] = telemetry.global_position.altitude
+            tel_dict["global_position"]["heading"] = telemetry.global_position.heading
+            tel_dict["relative_position"]["up"] = telemetry.relative_position.up
+            tel_dict["velocity_body"]["forward"] = telemetry.velocity_body.forward_vel
+            tel_dict["velocity_body"]["right"] = telemetry.velocity_body.right_vel
+            tel_dict["velocity_body"]["up"] = telemetry.velocity_body.up_vel
+            tel_dict["velocity_body"]["angular"] = telemetry.velocity_body.angular_vel
+            tel_dict["gimbal_pose"]["yaw"] = telemetry.gimbal_pose.yaw
+            tel_dict["gimbal_pose"]["pitch"] = telemetry.gimbal_pose.pitch
+            tel_dict["gimbal_pose"]["roll"] = telemetry.gimbal_pose.roll
             logger.debug(f"Received telemetry message: {telemetry}")
             await asyncio.sleep(0.3)  # Small delay to avoid hogging CPU
         except Exception as e:
             logger.error(f"Telemetry handler error: {e}")
+
 
 @pytest_asyncio.fixture(scope="function", autouse=True)
 async def start_telemetry_listener():
@@ -84,22 +94,24 @@ async def start_telemetry_listener():
         await telemetry_task
     except asyncio.CancelledError:
         logger.info("Telemetry listener task cancelled")
-        
+
+
 @pytest.fixture(scope="class")
 def sequence_counter():
     return {"value": 0}
 
+
 class TestSuiteClass:
-    identity = b'usr'
+    identity = b"usr"
     r_earth = 6378137.0
-    dx = 1 # Meters/s
-    dy = 1 # Meters/s
-    dz = 1 # Meters/s
-    d_xx = 5 # Meters
-    d_yy = 5 # Meters
-    d_zz = 5 # Meters
-    d_angle = 10 # Degrees
-    
+    dx = 1  # Meters/s
+    dy = 1  # Meters/s
+    dz = 1  # Meters/s
+    d_xx = 5  # Meters
+    d_yy = 5  # Meters
+    d_zz = 5  # Meters
+    d_angle = 10  # Degrees
+
     @pytest.mark.order(1)
     @pytest.mark.asyncio
     async def test_takeoff(self, sequence_counter):
@@ -109,36 +121,36 @@ class TestSuiteClass:
         driver_cmd.seq_num = sequence_counter["value"]
         message = driver_cmd.SerializeToString()
         await hub_to_driver_sock.send_multipart([self.identity, message])
- 
-        logger.info("Waiting for response")       
+
+        logger.info("Waiting for response")
         response = await hub_to_driver_sock.recv_multipart()
         driver_rep = control_protocol.Response()
         driver_rep.ParseFromString(response[1])
         seq_num = driver_rep.seq_num
         status = driver_rep.resp
-        
+
         logger.info(f"Received response with seqNum: {seq_num}")
         assert seq_num == sequence_counter["value"]
         logger.info(f"Status: {status}")
         assert status == common_protocol.ResponseStatus.COMPLETED
-        
+
         sequence_counter["value"] += 1
-        
+
     velocity_body_test_sets = [
-        (dy, 0, 0, 0), # Forward
-        (0, dx, 0, 0), # Right
-        (0, 0, dz, 0), # Up
-        (0, 0, 0, d_angle), # Yaw 1 radian
+        (dy, 0, 0, 0),  # Forward
+        (0, dx, 0, 0),  # Right
+        (0, 0, dz, 0),  # Up
+        (0, 0, 0, d_angle),  # Yaw 1 radian
     ]
-    
+
     @pytest.mark.order(2)
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test", velocity_body_test_sets)
     async def test_set_velocity_body(self, sequence_counter, test):
         logger.info("Testing set velocity")
-        
+
         forward, right, up, angular = test
-        
+
         logger.info(f"Testing set velocity body: {test}")
         driver_cmd = control_protocol.Request()
         driver_cmd.veh.velocity_body.forward_vel = forward
@@ -148,63 +160,66 @@ class TestSuiteClass:
         driver_cmd.seq_num = sequence_counter["value"]
         message = driver_cmd.SerializeToString()
         await hub_to_driver_sock.send_multipart([self.identity, message])
-        
+
         logger.info("Waiting for response")
         response = await hub_to_driver_sock.recv_multipart()
         driver_rep = control_protocol.Response()
         driver_rep.ParseFromString(response[1])
         seq_num = driver_rep.seq_num
         status = driver_rep.resp
-        
+
         logger.info(f"Received response with seqNum: {seq_num}")
         assert seq_num == sequence_counter["value"]
         logger.info(f"Status: {status}")
         assert status == common_protocol.ResponseStatus.COMPLETED
-        
+
         sequence_counter["value"] += 1
 
         # Wait to get up to speed
         await asyncio.sleep(10)
 
-        actual_forward = tel_dict['velocity_body']['forward']
-        actual_right = tel_dict['velocity_body']['right']
-        actual_up = tel_dict['velocity_body']['up']
-        actual_angular = tel_dict['velocity_body']['angular']
+        actual_forward = tel_dict["velocity_body"]["forward"]
+        actual_right = tel_dict["velocity_body"]["right"]
+        actual_up = tel_dict["velocity_body"]["up"]
+        actual_angular = tel_dict["velocity_body"]["angular"]
 
         assert np.allclose(
             [forward, right, up, angular],
             [actual_forward, actual_right, actual_up, actual_angular],
-            atol=3e-1
+            atol=3e-1,
         )
-    
-    @pytest.mark.order(3)    
+
+    @pytest.mark.order(3)
     @pytest.mark.asyncio
     async def test_set_relative_position(self, sequence_counter):
         assert True
-    
-    ''' Helper functions for global position testing ''' 
+
+    """ Helper functions for global position testing """
+
     def dy_to_lat(self, dy):
         return (dy / self.r_earth) * (180 / math.pi)
-    
-    def dx_to_lon(self, dx, lat ):
-        return (dx / self.r_earth) * (180 / math.pi) / math.cos(lat* math.pi/180)
-    
+
+    def dx_to_lon(self, dx, lat):
+        return (dx / self.r_earth) * (180 / math.pi) / math.cos(lat * math.pi / 180)
+
     def get_curr_loc(self):
         logger.info(f"Current telemetry: {tel_dict}")
-        curr_pos_alt = tel_dict['global_position']['altitude']
-        curr_pos_lat = tel_dict['global_position']['latitude']
-        curr_pos_lon = tel_dict['global_position']['longitude']
-        curr_pos_angle = tel_dict['global_position']['heading']
-        logger.info(f"Current position: {curr_pos_lat}, {curr_pos_lon}, {curr_pos_alt}, {curr_pos_angle}")
+        curr_pos_alt = tel_dict["global_position"]["altitude"]
+        curr_pos_lat = tel_dict["global_position"]["latitude"]
+        curr_pos_lon = tel_dict["global_position"]["longitude"]
+        curr_pos_angle = tel_dict["global_position"]["heading"]
+        logger.info(
+            f"Current position: {curr_pos_lat}, {curr_pos_lon}, {curr_pos_alt}, {curr_pos_angle}"
+        )
         return (curr_pos_lat, curr_pos_lon, curr_pos_alt, curr_pos_angle)
-   
+
     # Test sets for absolute altitude
     global_position_abs_test_sets = [
-        (d_xx, 0, 0, 0),   # Forward
-        (0, d_yy, 0, 0),   # Right
-        (0, 0, d_zz, 0),   # Up
+        (d_xx, 0, 0, 0),  # Forward
+        (0, d_yy, 0, 0),  # Right
+        (0, 0, d_zz, 0),  # Up
         (0, 0, 0, d_angle),  # Yaw +d_bearing
-        (-d_xx, -d_yy, -d_zz, 0) # Reset
+        (-d_xx, -d_yy, -d_zz, 0),  # Reset
     ]
 
     @pytest.mark.order(4)
@@ -229,13 +244,17 @@ class TestSuiteClass:
         next_alt = curr_pos_alt + d_alt
         next_angle = curr_pos_angle + d_angle
 
-        logger.info(f"Testing set global position to: {(next_lat, next_lon, next_alt, next_angle)}")
+        logger.info(
+            f"Testing set global position to: {(next_lat, next_lon, next_alt, next_angle)}"
+        )
         driver_cmd = control_protocol.Request()
-        driver_cmd.veh.location.latitude  = next_lat
+        driver_cmd.veh.location.latitude = next_lat
         driver_cmd.veh.location.longitude = next_lon
-        driver_cmd.veh.location.altitude  = next_alt
+        driver_cmd.veh.location.altitude = next_alt
         driver_cmd.veh.location.heading = next_angle
-        driver_cmd.veh.location.heading_mode = common_protocol.LocationHeadingMode.HEADING_START
+        driver_cmd.veh.location.heading_mode = (
+            common_protocol.LocationHeadingMode.HEADING_START
+        )
         seq = sequence_counter["value"]
         logger.info(f"Sending command with seqNum: {seq}")
         driver_cmd.seq_num = sequence_counter["value"]
@@ -248,18 +267,18 @@ class TestSuiteClass:
         driver_rep.ParseFromString(response[1])
         seq_num = driver_rep.seq_num
         status = driver_rep.resp
-        
+
         logger.info(f"Received response {driver_rep}")
         logger.info(f"Received response with seqNum: {seq_num}")
         assert seq_num == sequence_counter["value"]
         logger.info(f"Status: {status}")
         assert status == common_protocol.ResponseStatus.COMPLETED
-        
+
         # Check the telemetry to see if the move was OK
-        actual_lat = tel_dict['global_position']['latitude']
-        actual_lon = tel_dict['global_position']['longitude']
-        actual_alt = tel_dict['global_position']['altitude']
-        actual_angle = tel_dict['global_position']['heading']
+        actual_lat = tel_dict["global_position"]["latitude"]
+        actual_lon = tel_dict["global_position"]["longitude"]
+        actual_alt = tel_dict["global_position"]["altitude"]
+        actual_angle = tel_dict["global_position"]["heading"]
 
         logger.info(f"Expected: {(next_lat, next_lon, next_alt, next_angle)}")
         logger.info(f"Actual:   {(actual_lat, actual_lon, actual_alt, actual_angle)}")
@@ -268,38 +287,41 @@ class TestSuiteClass:
         assert np.allclose([next_lat, next_lon], [actual_lat, actual_lon], atol=1e-5)
         assert np.isclose(next_alt, actual_alt, atol=1)
         # TODO: Figure out why the heading is not being set correctly
-        #abs_diff = abs(next_angle - actual_angle)
-        #diff = min(abs_diff, 360 - abs_diff)
-        #assert diff <= 4
-        
+        # abs_diff = abs(next_angle - actual_angle)
+        # diff = min(abs_diff, 360 - abs_diff)
+        # assert diff <= 4
+
         sequence_counter["value"] += 1
 
     # Test sets for relative altitude
-    global_position_rel_test_sets = [
-        (0, 0, d_zz, 0),
-        (0, 0, -d_zz, 0)
-    ]
+    global_position_rel_test_sets = [(0, 0, d_zz, 0), (0, 0, -d_zz, 0)]
 
     @pytest.mark.order(5)
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test", global_position_rel_test_sets)
     async def test_set_global_position_altitude_relative(self, sequence_counter, test):
         logger.info("Testing set global position with relative altitude")
-        
+
         # Get initial position
         curr_pos_lat, curr_pos_lon, curr_pos_alt, curr_pos_angle = self.get_curr_loc()
-        
+
         x, y, z, angle = test
-        
+
         # Test out the different altitude control modes
-        logger.info(f"Testing set global position to: {(curr_pos_lat, curr_pos_lon, curr_pos_alt + self.d_zz, curr_pos_angle)}")
+        logger.info(
+            f"Testing set global position to: {(curr_pos_lat, curr_pos_lon, curr_pos_alt + self.d_zz, curr_pos_angle)}"
+        )
         driver_cmd = control_protocol.Request()
-        driver_cmd.veh.location.latitude  = curr_pos_lat + x
+        driver_cmd.veh.location.latitude = curr_pos_lat + x
         driver_cmd.veh.location.longitude = curr_pos_lon + y
-        driver_cmd.veh.location.altitude  = curr_pos_alt + z
-        driver_cmd.veh.location.altitude_mode = common_protocol.LocationAltitudeMode.TAKEOFF_RELATIVE
+        driver_cmd.veh.location.altitude = curr_pos_alt + z
+        driver_cmd.veh.location.altitude_mode = (
+            common_protocol.LocationAltitudeMode.TAKEOFF_RELATIVE
+        )
         driver_cmd.veh.location.heading = curr_pos_angle + angle
-        driver_cmd.veh.location.heading_mode = common_protocol.LocationHeadingMode.HEADING_START
+        driver_cmd.veh.location.heading_mode = (
+            common_protocol.LocationHeadingMode.HEADING_START
+        )
         seq = sequence_counter["value"]
         logger.info(f"Sending command with seqNum: {seq}")
         driver_cmd.seq_num = sequence_counter["value"]
@@ -312,30 +334,34 @@ class TestSuiteClass:
         driver_rep.ParseFromString(response[1])
         seq_num = driver_rep.seq_num
         status = driver_rep.resp
-        
+
         logger.info(f"Received response {driver_rep}")
         logger.info(f"Received response with seqNum: {seq_num}")
         assert seq_num == sequence_counter["value"]
         logger.info(f"Status: {status}")
         assert status == common_protocol.ResponseStatus.COMPLETED
-        
-        # Check the telemetry to see if the move was OK
-        actual_lat = tel_dict['global_position']['latitude']
-        actual_lon = tel_dict['global_position']['longitude']
-        actual_alt = tel_dict['global_position']['altitude']
-        actual_angle = tel_dict['global_position']['heading']
 
-        logger.info(f"Expected: {(curr_pos_lat, curr_pos_lon, curr_pos_alt + self.d_zz, curr_pos_angle)}")
+        # Check the telemetry to see if the move was OK
+        actual_lat = tel_dict["global_position"]["latitude"]
+        actual_lon = tel_dict["global_position"]["longitude"]
+        actual_alt = tel_dict["global_position"]["altitude"]
+        actual_angle = tel_dict["global_position"]["heading"]
+
+        logger.info(
+            f"Expected: {(curr_pos_lat, curr_pos_lon, curr_pos_alt + self.d_zz, curr_pos_angle)}"
+        )
         logger.info(f"Actual: {(actual_lat, actual_lon, actual_alt, actual_angle)}")
 
         # Validate with some tolerance
-        assert np.allclose([curr_pos_lat, curr_pos_lon], [actual_lat, actual_lon], atol=1e-5)
+        assert np.allclose(
+            [curr_pos_lat, curr_pos_lon], [actual_lat, actual_lon], atol=1e-5
+        )
         assert np.isclose(curr_pos_alt + z, actual_alt, atol=1)
         # TODO: Figure out why heading is not set correctly
-        #abs_diff = abs(curr_pos_angle - actual_angle)
-        #diff = min(abs_diff, 360 - abs_diff)
-        #assert diff <= 4
-        
+        # abs_diff = abs(curr_pos_angle - actual_angle)
+        # diff = min(abs_diff, 360 - abs_diff)
+        # assert diff <= 4
+
         sequence_counter["value"] += 1
 
     # Test cases for set gimbal pose
@@ -362,19 +388,23 @@ class TestSuiteClass:
         logger.info("Testing set gimbal pose")
 
         yaw, pitch, roll, mode = test
-        logger.info(f"Testing set gimbal pose to: {(yaw, pitch, roll)}, (yaw, pitch, roll) format")
+        logger.info(
+            f"Testing set gimbal pose to: {(yaw, pitch, roll)}, (yaw, pitch, roll) format"
+        )
         # Store current pose for relative testing
-        curr_yaw = tel_dict['gimbal_pose']['yaw']
-        curr_pitch = tel_dict['gimbal_pose']['pitch']
-        curr_roll = tel_dict['gimbal_pose']['roll']
-        
+        curr_yaw = tel_dict["gimbal_pose"]["yaw"]
+        curr_pitch = tel_dict["gimbal_pose"]["pitch"]
+        curr_roll = tel_dict["gimbal_pose"]["roll"]
+
         driver_cmd = control_protocol.Request()
-        driver_cmd.veh.gimbal_pose.yaw   = yaw
+        driver_cmd.veh.gimbal_pose.yaw = yaw
         driver_cmd.veh.gimbal_pose.pitch = pitch
-        driver_cmd.veh.gimbal_pose.roll  = roll
+        driver_cmd.veh.gimbal_pose.roll = roll
         # Mode defaults to POSITION_ABSOLUTE
         if mode == 1:
-            driver_cmd.veh.gimbal_pose.control_mode = common_protocol.PoseControlMode.POSITION_RELATIVE
+            driver_cmd.veh.gimbal_pose.control_mode = (
+                common_protocol.PoseControlMode.POSITION_RELATIVE
+            )
         seq = sequence_counter["value"]
         logger.info(f"Sending command with seqNum: {seq}")
         driver_cmd.seq_num = sequence_counter["value"]
@@ -387,17 +417,17 @@ class TestSuiteClass:
         driver_rep.ParseFromString(response[1])
         seq_num = driver_rep.seq_num
         status = driver_rep.resp
-        
+
         logger.info(f"Received response {driver_rep}")
         logger.info(f"Received response with seqNum: {seq_num}")
         assert seq_num == sequence_counter["value"]
         logger.info(f"Status: {status}")
         assert status == common_protocol.ResponseStatus.COMPLETED
-        
+
         # Check the telemetry to see if the move was OK
-        actual_yaw = tel_dict['gimbal_pose']['yaw']
-        actual_pitch = tel_dict['gimbal_pose']['pitch']
-        actual_roll = tel_dict['gimbal_pose']['roll']
+        actual_yaw = tel_dict["gimbal_pose"]["yaw"]
+        actual_pitch = tel_dict["gimbal_pose"]["pitch"]
+        actual_roll = tel_dict["gimbal_pose"]["roll"]
 
         if mode == 0:
             exp_yaw = yaw
@@ -412,17 +442,21 @@ class TestSuiteClass:
         logger.info(f"Actual: {(actual_yaw, actual_pitch, actual_roll)}")
 
         # Validate with some tolerance
-        assert np.allclose([exp_yaw, exp_pitch, exp_roll], [actual_yaw, actual_pitch, actual_roll], atol=3e-1)
-        
+        assert np.allclose(
+            [exp_yaw, exp_pitch, exp_roll],
+            [actual_yaw, actual_pitch, actual_roll],
+            atol=3e-1,
+        )
+
         sequence_counter["value"] += 1
-        
+
     @pytest.mark.order(7)
     @pytest.mark.asyncio
     async def test_set_heading(self, sequence_counter):
         logger.info("Testing set heading")
         # TODO: No way to directly call set heading...
 
-    @pytest.mark.order(8)        
+    @pytest.mark.order(8)
     @pytest.mark.asyncio
     async def test_RTH(self, sequence_counter):
         logger.info("Testing return to home")
@@ -431,21 +465,21 @@ class TestSuiteClass:
         request.seq_num = sequence_counter["value"]
         message = request.SerializeToString()
         await hub_to_driver_sock.send_multipart([self.identity, message])
-        
+
         logger.info("Waiting for response")
         response = await hub_to_driver_sock.recv_multipart()
         driver_rep = control_protocol.Response()
         driver_rep.ParseFromString(response[1])
-        seq_num = driver_rep.seq_num  
+        seq_num = driver_rep.seq_num
         status = driver_rep.resp
-        
+
         logger.info(f"Received response with seqNum: {seq_num}")
         assert seq_num == sequence_counter["value"]
         logger.info(f"Status: {driver_rep.resp}")
         assert status == common_protocol.ResponseStatus.COMPLETED
         sequence_counter["value"] += 1
-        
-    @pytest.mark.order(9)        
+
+    @pytest.mark.order(9)
     @pytest.mark.asyncio
     async def test_land(self, sequence_counter):
         logger.info("Testing land")
@@ -454,17 +488,16 @@ class TestSuiteClass:
         request.seq_num = sequence_counter["value"]
         message = request.SerializeToString()
         await hub_to_driver_sock.send_multipart([self.identity, message])
-        
+
         logger.info("Waiting for response")
         response = await hub_to_driver_sock.recv_multipart()
         driver_rep = control_protocol.Response()
         driver_rep.ParseFromString(response[1])
         seq_num = driver_rep.seq_num
         status = driver_rep.resp
-        
+
         logger.info(f"Received response with seqNum: {seq_num}")
         assert seq_num == sequence_counter["value"]
         logger.info(f"Status: {status}")
         assert status == common_protocol.ResponseStatus.COMPLETED
         sequence_counter["value"] += 1
-        

--- a/vehicle/drivers/multicopter/test/auto_test_suite.py
+++ b/vehicle/drivers/multicopter/test/auto_test_suite.py
@@ -1,16 +1,18 @@
 import asyncio
 import logging
-import zmq
-import zmq.asyncio
-from util.utils import setup_socket, SocketOperation
-import pytest_asyncio
-import pytest
-import numpy as np
 import math
+
+import common_pb2 as common_protocol
+import controlplane_pb2 as control_protocol
+
 # Import SteelEagle protocol
 import dataplane_pb2 as data_protocol
-import controlplane_pb2 as control_protocol
-import common_pb2 as common_protocol
+import numpy as np
+import pytest
+import pytest_asyncio
+import zmq
+import zmq.asyncio
+from util.utils import SocketOperation, setup_socket
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/drivers/multicopter/test/manual_test_runner.py
+++ b/vehicle/drivers/multicopter/test/manual_test_runner.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 import controlplane_pb2 as control_protocol
 import dataplane_pb2 as data_protocol
+import gabriel_extras_pb2 as gabriel_extras
 import zmq
 import zmq.asyncio
 from pynput.keyboard import Key, KeyCode, Listener
@@ -173,7 +174,7 @@ async def recv_camera():
     while True:
         try:
             msg = await cam_sock.recv()
-            frame = cnc_pb2.Frame()
+            frame = gabriel_extras.Frame()
             frame.ParseFromString(msg)
             logger.debug(f"Received camera message after set: {frame}")
             await asyncio.sleep(0.3)

--- a/vehicle/drivers/multicopter/test/manual_test_runner.py
+++ b/vehicle/drivers/multicopter/test/manual_test_runner.py
@@ -1,6 +1,5 @@
 from pynput.keyboard import Listener, Key, KeyCode
 from enum import Enum
-import subprocess
 import logging
 import time
 import zmq
@@ -10,7 +9,6 @@ from collections import defaultdict
 from util.utils import setup_socket, SocketOperation
 import controlplane_pb2 as control_protocol
 import dataplane_pb2 as data_protocol
-import common_pb2 as common_protocol
 
 class Ctrl(Enum):
     (

--- a/vehicle/drivers/multicopter/test/manual_test_runner.py
+++ b/vehicle/drivers/multicopter/test/manual_test_runner.py
@@ -28,6 +28,7 @@ class Ctrl(Enum):
         TURN_RIGHT,
     ) = range(12)
 
+
 QWERTY_CTRL_KEYS = {
     Ctrl.QUIT: Key.esc,
     Ctrl.TAKEOFF: "t",
@@ -42,6 +43,7 @@ QWERTY_CTRL_KEYS = {
     Ctrl.TURN_LEFT: Key.left,
     Ctrl.TURN_RIGHT: Key.right,
 }
+
 
 class KeyboardCtrl(Listener):
     def __init__(self, speeds, ctrl_keys=None):
@@ -73,32 +75,26 @@ class KeyboardCtrl(Listener):
         return not self.running or self._key_pressed[self._ctrl_keys[Ctrl.QUIT]]
 
     def _axis(self, left_key, right_key):
-        return  (
-            int(self._key_pressed[right_key]) - int(self._key_pressed[left_key])
-        )
+        return int(self._key_pressed[right_key]) - int(self._key_pressed[left_key])
 
     def roll(self):
         return self.speeds["roll"] * self._axis(
-            self._ctrl_keys[Ctrl.MOVE_LEFT],
-            self._ctrl_keys[Ctrl.MOVE_RIGHT]
+            self._ctrl_keys[Ctrl.MOVE_LEFT], self._ctrl_keys[Ctrl.MOVE_RIGHT]
         )
 
     def pitch(self):
         return self.speeds["pitch"] * self._axis(
-            self._ctrl_keys[Ctrl.MOVE_BACKWARD],
-            self._ctrl_keys[Ctrl.MOVE_FORWARD]
+            self._ctrl_keys[Ctrl.MOVE_BACKWARD], self._ctrl_keys[Ctrl.MOVE_FORWARD]
         )
 
     def yaw(self):
         return self.speeds["yaw"] * self._axis(
-            self._ctrl_keys[Ctrl.TURN_LEFT],
-            self._ctrl_keys[Ctrl.TURN_RIGHT]
+            self._ctrl_keys[Ctrl.TURN_LEFT], self._ctrl_keys[Ctrl.TURN_RIGHT]
         )
 
     def throttle(self):
         return self.speeds["throttle"] * self._axis(
-            self._ctrl_keys[Ctrl.MOVE_DOWN],
-            self._ctrl_keys[Ctrl.MOVE_UP]
+            self._ctrl_keys[Ctrl.MOVE_DOWN], self._ctrl_keys[Ctrl.MOVE_UP]
         )
 
     def has_piloting_cmd(self):
@@ -124,7 +120,7 @@ class KeyboardCtrl(Listener):
 
     def landing(self):
         return self._rate_limit_cmd(Ctrl.LANDING, 2.0)
-    
+
     def rth(self):
         return self._rate_limit_cmd(Ctrl.RTH, 2.0)
 
@@ -140,19 +136,26 @@ logger = logging.getLogger(__name__)
 context = zmq.asyncio.Context()
 
 hub_to_driver_sock = context.socket(zmq.DEALER)
-setup_socket(hub_to_driver_sock, SocketOperation.BIND, 'hub.network.controlplane.hub_to_driver')
+setup_socket(
+    hub_to_driver_sock, SocketOperation.BIND, "hub.network.controlplane.hub_to_driver"
+)
 
 tel_sock = context.socket(zmq.SUB)
-tel_sock.setsockopt(zmq.SUBSCRIBE, b'') # Subscribe to all topics
+tel_sock.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics
 tel_sock.setsockopt(zmq.CONFLATE, 1)
-setup_socket(tel_sock, SocketOperation.BIND, 'hub.network.dataplane.driver_to_hub.telemetry')
+setup_socket(
+    tel_sock, SocketOperation.BIND, "hub.network.dataplane.driver_to_hub.telemetry"
+)
 
 cam_sock = context.socket(zmq.SUB)
-cam_sock.setsockopt(zmq.SUBSCRIBE, b'')  # Subscribe to all topics
+cam_sock.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics
 cam_sock.setsockopt(zmq.CONFLATE, 1)
-setup_socket(cam_sock, SocketOperation.BIND, 'hub.network.dataplane.driver_to_hub.image_sensor')
+setup_socket(
+    cam_sock, SocketOperation.BIND, "hub.network.dataplane.driver_to_hub.image_sensor"
+)
 
 command_seq = 0
+
 
 async def recv_telemetry():
     while True:
@@ -164,7 +167,8 @@ async def recv_telemetry():
             await asyncio.sleep(0.3)
         except Exception as e:
             logger.error(f"Telemetry handler error: {e}")
-    
+
+
 async def recv_camera():
     while True:
         try:
@@ -176,53 +180,56 @@ async def recv_camera():
         except Exception as e:
             logger.error(f"Camera handler error: {e}")
 
+
 async def send_comm(control):
     global command_seq
     driver_command = control_protocol.Request()
-    
+
     driver_command.seq_num = command_seq
     driver_command.timestamp.GetCurrentTime()
-    
+
     command_seq += 1
 
     if control.takeoff():
-        logger.info('Takeoff!')
+        logger.info("Takeoff!")
         driver_command.veh.action = control_protocol.VehicleAction.TAKEOFF
     elif control.landing():
-        logger.info('Land!')
+        logger.info("Land!")
         driver_command.veh.action = control_protocol.VehicleAction.LAND
     elif control.rth():
-        logger.info('RTH!')
+        logger.info("RTH!")
         driver_command.veh.action = control_protocol.VehicleAction.RTH
     elif control.has_piloting_cmd():
-        logger.info(f'Velocity({control.pitch()}, {control.roll()}, {control.throttle()}, {control.yaw()})')
+        logger.info(
+            f"Velocity({control.pitch()}, {control.roll()}, {control.throttle()}, {control.yaw()})"
+        )
         driver_command.veh.velocity_body.forward_vel = control.pitch()
         driver_command.veh.velocity_body.right_vel = control.roll()
         driver_command.veh.velocity_body.up_vel = control.throttle()
         driver_command.veh.velocity_body.angular_vel = control.yaw()
     else:
-        logger.info('Hover.')
+        logger.info("Hover.")
         driver_command.veh.action = control_protocol.VehicleAction.HOVER
 
     message = driver_command.SerializeToString()
-    identity = b'cmdr'
+    identity = b"cmdr"
     await hub_to_driver_sock.send_multipart([identity, message])
-    logger.info('Sent message.')
+    logger.info("Sent message.")
     resp = await hub_to_driver_sock.recv_multipart()
 
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
-async def main(): 
-    speeds = {
-        "pitch" : 1,
-        "roll" : 1,
-        "yaw" : 25,
-        "throttle" : 1
-    }
+logging.basicConfig(
+    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+async def main():
+    speeds = {"pitch": 1, "roll": 1, "yaw": 25, "throttle": 1}
     control = KeyboardCtrl(speeds)
-    #asyncio.create_task(recv_telemetry())
+    # asyncio.create_task(recv_telemetry())
     while not control.quit():
-        await send_comm(control) 
+        await send_comm(control)
         await asyncio.sleep(0.2)
+
 
 asyncio.run(main())

--- a/vehicle/drivers/multicopter/test/manual_test_runner.py
+++ b/vehicle/drivers/multicopter/test/manual_test_runner.py
@@ -1,14 +1,16 @@
-from pynput.keyboard import Listener, Key, KeyCode
-from enum import Enum
+import asyncio
 import logging
 import time
-import zmq
-import zmq.asyncio
-import asyncio
 from collections import defaultdict
-from util.utils import setup_socket, SocketOperation
+from enum import Enum
+
 import controlplane_pb2 as control_protocol
 import dataplane_pb2 as data_protocol
+import zmq
+import zmq.asyncio
+from pynput.keyboard import Key, KeyCode, Listener
+from util.utils import SocketOperation, setup_socket
+
 
 class Ctrl(Enum):
     (

--- a/vehicle/hub/__main__.py
+++ b/vehicle/hub/__main__.py
@@ -1,12 +1,12 @@
 import asyncio
-import logging
 import importlib
+import logging
 import pkgutil
 
 from control_service import ControlService
 from data_service import DataService
-from datasinks.ComputeItf import ComputeInterface
 from data_store import DataStore
+from datasinks.ComputeItf import ComputeInterface
 from util.utils import query_config, setup_logging
 
 logger = logging.getLogger(__name__)

--- a/vehicle/hub/__main__.py
+++ b/vehicle/hub/__main__.py
@@ -11,18 +11,27 @@ from util.utils import query_config, setup_logging
 
 logger = logging.getLogger(__name__)
 
+
 def discover_compute_classes():
     """Discover all compute classes dynamically from datasinks."""
     import datasinks
+
     compute_classes = {}
-    for module_info in pkgutil.iter_modules(datasinks.__path__, datasinks.__name__ + "."):
+    for module_info in pkgutil.iter_modules(
+        datasinks.__path__, datasinks.__name__ + "."
+    ):
         module_name = module_info.name
         module = importlib.import_module(module_name)
         for attr_name in dir(module):
             attr = getattr(module, attr_name)
-            if isinstance(attr, type) and issubclass(attr, ComputeInterface) and attr is not ComputeInterface:
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, ComputeInterface)
+                and attr is not ComputeInterface
+            ):
                 compute_classes[attr_name.lower()] = attr
     return compute_classes
+
 
 def run_compute_tasks(data_store, compute_dict):
     """Instantiate and launch compute modules."""
@@ -31,7 +40,7 @@ def run_compute_tasks(data_store, compute_dict):
 
     tasks = []
 
-    for compute_config in query_config('hub.computes'):
+    for compute_config in query_config("hub.computes"):
         compute_class = compute_config["compute_class"].lower()
         compute_id = compute_config["compute_id"]
 
@@ -50,8 +59,9 @@ def run_compute_tasks(data_store, compute_dict):
 
     return tasks
 
+
 async def main():
-    setup_logging(logger, 'hub.logging')
+    setup_logging(logger, "hub.logging")
     logger.info("Launching unified hub services")
 
     # Shared resources
@@ -65,11 +75,8 @@ async def main():
     data_service = DataService(data_store, compute_dict)
     command_service = ControlService(data_store, compute_dict)
 
-    await asyncio.gather(
-        data_service.start(),
-        command_service.start(),
-        *compute_tasks
-    )
+    await asyncio.gather(data_service.start(), command_service.start(), *compute_tasks)
+
 
 if __name__ == "__main__":
     try:

--- a/vehicle/hub/control_service.py
+++ b/vehicle/hub/control_service.py
@@ -1,14 +1,15 @@
+import asyncio
+import logging
+import time
+
+import common_pb2 as common_protocol
+import controlplane_pb2 as control_protocol
 import validators
 import zmq
 import zmq.asyncio
-import asyncio
-import logging
-import controlplane_pb2 as control_protocol
-import common_pb2 as common_protocol
-from service import Service
-from util.utils import query_config, setup_logging, SocketOperation
 from data_store import DataStore
-import time
+from service import Service
+from util.utils import SocketOperation, query_config, setup_logging
 
 logger = logging.getLogger(__name__)
 setup_logging(logger, 'hub.logging')

--- a/vehicle/hub/control_service.py
+++ b/vehicle/hub/control_service.py
@@ -12,7 +12,8 @@ from service import Service
 from util.utils import SocketOperation, query_config, setup_logging
 
 logger = logging.getLogger(__name__)
-setup_logging(logger, 'hub.logging')
+setup_logging(logger, "hub.logging")
+
 
 class ControlService(Service):
     def __init__(self, data_store: DataStore, compute_dict):
@@ -20,40 +21,49 @@ class ControlService(Service):
         super().__init__()
         self.compute_dict = compute_dict
         self.data_store = data_store
-        
+
         self.waypoint_req = None
 
         # Drone info
-        self.drone_id = query_config('driver.id')
-        self.drone_type = query_config('driver.type')
+        self.drone_id = query_config("driver.id")
+        self.drone_type = query_config("driver.type")
         self.manual = True
 
         # Communication sockets
         self.commander_socket = self.context.socket(zmq.DEALER)
-        self.commander_socket.setsockopt(zmq.IDENTITY, self.drone_id.encode('utf-8'))
+        self.commander_socket.setsockopt(zmq.IDENTITY, self.drone_id.encode("utf-8"))
         self.last_manual_message = None
 
         self.mission_cmd_socket = self.context.socket(zmq.DEALER)
         self.mission_report_socket = self.context.socket(zmq.DEALER)
         self.driver_socket = self.context.socket(zmq.DEALER)
         self.mission_ctrl_socket = self.context.socket(zmq.REQ)
-        
 
         self.setup_and_register_socket(
-            self.commander_socket, SocketOperation.CONNECT,
-            'hub.network.cloudlet.commander_to_hub')
+            self.commander_socket,
+            SocketOperation.CONNECT,
+            "hub.network.cloudlet.commander_to_hub",
+        )
         self.setup_and_register_socket(
-            self.mission_cmd_socket, SocketOperation.BIND,
-            'hub.network.controlplane.mission_to_hub')
+            self.mission_cmd_socket,
+            SocketOperation.BIND,
+            "hub.network.controlplane.mission_to_hub",
+        )
         self.setup_and_register_socket(
-            self.mission_report_socket, SocketOperation.BIND,
-            'hub.network.controlplane.mission_to_hub_2')
+            self.mission_report_socket,
+            SocketOperation.BIND,
+            "hub.network.controlplane.mission_to_hub_2",
+        )
         self.setup_and_register_socket(
-            self.driver_socket, SocketOperation.BIND,
-            'hub.network.controlplane.hub_to_driver')
+            self.driver_socket,
+            SocketOperation.BIND,
+            "hub.network.controlplane.hub_to_driver",
+        )
         self.setup_and_register_socket(
-            self.mission_ctrl_socket, SocketOperation.BIND,
-            'hub.network.controlplane.hub_to_mission')
+            self.mission_ctrl_socket,
+            SocketOperation.BIND,
+            "hub.network.controlplane.hub_to_mission",
+        )
 
         # Start poller loop
         self.create_task(self.cmd_proxy())
@@ -63,7 +73,7 @@ class ControlService(Service):
     ###########################################################################
     async def cmd_proxy(self):
         """Unified socket poller handling messages from commander, mission, and driver."""
-        logger.info('Command proxy started')
+        logger.info("Command proxy started")
         poller = zmq.asyncio.Poller()
         poller.register(self.commander_socket, zmq.POLLIN)
         poller.register(self.driver_socket, zmq.POLLIN)
@@ -75,13 +85,17 @@ class ControlService(Service):
                 socks = dict(await poller.poll(timeout=0.5))
 
                 # Skip our checks if no messages were delivered.
-                # However, if no commands were recieved and we 
+                # However, if no commands were recieved and we
                 # are in manual mode, go into failsafe.
                 if not len(socks):
-                    if self.manual and \
-                            self.last_manual_message and \
-                            time.time() - self.last_manual_message >= 1.0:
-                        logger.info("FAILSAFE ACTIVATED - Swarm controller is likely disconnected...")
+                    if (
+                        self.manual
+                        and self.last_manual_message
+                        and time.time() - self.last_manual_message >= 1.0
+                    ):
+                        logger.info(
+                            "FAILSAFE ACTIVATED - Swarm controller is likely disconnected..."
+                        )
                         await self.manual_disconnect_failsafe()
                         self.last_manual_message = None
                     continue
@@ -94,7 +108,7 @@ class ControlService(Service):
                 if self.mission_cmd_socket in socks:
                     msg = await self.mission_cmd_socket.recv_multipart()
                     await self.handle_mission_input(msg[0])
-                
+
                 if self.mission_report_socket in socks:
                     msg = await self.mission_report_socket.recv_multipart()
                     await self.handle_mission_report(msg[0])
@@ -111,7 +125,9 @@ class ControlService(Service):
     ###########################################################################
     async def manual_disconnect_failsafe(self):
         # Stops the drone if the swarm controller disconnects while in manual mode.
-        logger.debug("Executing manual disconnection failsafe, ordering the drone to hover!")
+        logger.debug(
+            "Executing manual disconnection failsafe, ordering the drone to hover!"
+        )
         req = control_protocol.Request()
         req.veh.action = control_protocol.VehicleAction.HOVER
         await self.process_vehicle_command(req)
@@ -134,14 +150,14 @@ class ControlService(Service):
                 raise Exception("Missing request type in commander command")
 
     async def handle_mission_input(self, cmd):
-        """Handles mission request and forwards to driver/commander."""    
+        """Handles mission request and forwards to driver/commander."""
         req = control_protocol.Request()
         req.ParseFromString(cmd)
         logger.info(f"Received mission request: {req}")
         match req.WhichOneof("type"):
             case "veh":
                 logger.debug(f"Forwarding vehicle command to driver: {req}")
-                await self.driver_socket.send_multipart([b'usr', cmd])
+                await self.driver_socket.send_multipart([b"usr", cmd])
             case "cpt":
                 logger.info(f"Processing compute control command: {req}")
                 match req.cpt.action:
@@ -157,34 +173,39 @@ class ControlService(Service):
             case _:
                 logger.warning("Unknown request type in mission message")
 
-
     async def handle_mission_report(self, report):
         """Handles mission report and forwards to commander."""
         resp = control_protocol.Response()
         resp.ParseFromString(report)
         logger.info(f"Received patrol report from mission: {resp}")
-        
-        if resp.resp == common_protocol.ResponseStatus.OK and self.waypoint_req is not None:
+
+        if (
+            resp.resp == common_protocol.ResponseStatus.OK
+            and self.waypoint_req is not None
+        ):
             logger.info("already have the cached waypoint")
             self.waypoint_req.seq_num = resp.seq_num
-            logger.info(f"Sending cached waypoint report to mission: {self.waypoint_req}")
+            logger.info(
+                f"Sending cached waypoint report to mission: {self.waypoint_req}"
+            )
             await self.mission_report_socket.send(self.waypoint_req.SerializeToString())
             return
-        
+
         logger.info(f"Forwarding mission report to commander: {report}")
         await self.commander_socket.send_multipart([report])
         self.waypoint_req = None
-   
 
     async def handle_driver_input(self, msg):
         """Handles message from driver and routes based on identity."""
         logger.debug(f"Received message from driver: {msg}")
         identity, cmd = msg
-        if identity == b'usr':
+        if identity == b"usr":
             logger.debug("Forwarding driver response back to mission")
             await self.mission_cmd_socket.send_multipart([cmd])
-        elif identity == b'cmdr':
-            logger.debug("proxy : driver_socket Received message from BACKEND: discard bc of cmdr")
+        elif identity == b"cmdr":
+            logger.debug(
+                "proxy : driver_socket Received message from BACKEND: discard bc of cmdr"
+            )
             pass
         else:
             logger.warning(f"Unknown identity received from driver: {identity}")
@@ -235,7 +256,9 @@ class ControlService(Service):
         compute_type = req.cpt.type
         for compute_id in self.compute_dict.keys():
             self.data_store.clear_compute_result(compute_id, compute_type)
-            logger.info(f"Cleared compute result for {compute_id} and type {compute_type}")
+            logger.info(
+                f"Cleared compute result for {compute_id} and type {compute_type}"
+            )
 
         reply = control_protocol.Response()
         reply.resp = common_protocol.ResponseStatus.COMPLETED
@@ -246,12 +269,22 @@ class ControlService(Service):
     async def configure_compute(self, req):
         logger.info("Configure compute")
         model = req.cpt.model
-        lower_bound = [req.cpt.lower_bound.h, req.cpt.lower_bound.s, req.cpt.lower_bound.v]
-        upper_bound = [req.cpt.upper_bound.h, req.cpt.upper_bound.s, req.cpt.upper_bound.v]
+        lower_bound = [
+            req.cpt.lower_bound.h,
+            req.cpt.lower_bound.s,
+            req.cpt.lower_bound.v,
+        ]
+        upper_bound = [
+            req.cpt.upper_bound.h,
+            req.cpt.upper_bound.s,
+            req.cpt.upper_bound.v,
+        ]
         for compute_id in self.compute_dict.keys():
             compute = self.compute_dict[compute_id]
             compute.set(model, lower_bound, upper_bound)
-            logger.info(f"Configured compute {compute_id} with model {model}, lower_bound {lower_bound}, upper_bound {upper_bound}")
+            logger.info(
+                f"Configured compute {compute_id} with model {model}, lower_bound {lower_bound}, upper_bound {upper_bound}"
+            )
 
         reply = control_protocol.Response()
         reply.resp = common_protocol.ResponseStatus.COMPLETED
@@ -259,10 +292,9 @@ class ControlService(Service):
         reply.seq_num = req.seq_num
         await self.mission_cmd_socket.send_multipart([reply.SerializeToString()])
 
-
     async def send_driver_command(self, req):
         """Sends a command to the driver."""
-        await self.driver_socket.send_multipart([b'cmdr', req.SerializeToString()])
+        await self.driver_socket.send_multipart([b"cmdr", req.SerializeToString()])
         logger.info(f"Sent command to driver: {req}")
 
     async def send_download_mission(self, req):
@@ -300,7 +332,3 @@ class ControlService(Service):
             self.waypoint_req = control_protocol.Request()
             self.waypoint_req.CopyFrom(req)
         await self.mission_report_socket.send(req.SerializeToString())
-
-
-
-

--- a/vehicle/hub/control_service.py
+++ b/vehicle/hub/control_service.py
@@ -8,7 +8,6 @@ import common_pb2 as common_protocol
 from service import Service
 from util.utils import query_config, setup_logging, SocketOperation
 from data_store import DataStore
-from google.protobuf.message import DecodeError
 import time
 
 logger = logging.getLogger(__name__)
@@ -165,7 +164,7 @@ class ControlService(Service):
         logger.info(f"Received patrol report from mission: {resp}")
         
         if resp.resp == common_protocol.ResponseStatus.OK and self.waypoint_req is not None:
-            logger.info(f"already have the cached waypoint")
+            logger.info("already have the cached waypoint")
             self.waypoint_req.seq_num = resp.seq_num
             logger.info(f"Sending cached waypoint report to mission: {self.waypoint_req}")
             await self.mission_report_socket.send(self.waypoint_req.SerializeToString())

--- a/vehicle/hub/data_service.py
+++ b/vehicle/hub/data_service.py
@@ -1,12 +1,13 @@
-import zmq
-import zmq.asyncio
 import asyncio
 import logging
-from util.utils import setup_logging, SocketOperation
-import dataplane_pb2 as data_protocol
+
 import common_pb2 as common_protocol
-from service import Service
+import dataplane_pb2 as data_protocol
+import zmq
+import zmq.asyncio
 from data_store import DataStore
+from service import Service
+from util.utils import SocketOperation, setup_logging
 
 logger = logging.getLogger(__name__)
 setup_logging(logger, 'hub.logging')

--- a/vehicle/hub/data_service.py
+++ b/vehicle/hub/data_service.py
@@ -2,7 +2,7 @@ import zmq
 import zmq.asyncio
 import asyncio
 import logging
-from util.utils import query_config, setup_logging, SocketOperation
+from util.utils import setup_logging, SocketOperation
 import dataplane_pb2 as data_protocol
 import common_pb2 as common_protocol
 from service import Service
@@ -115,7 +115,7 @@ class DataService(Service):
             case "cpt":
                 await self.process_compute_req(req)
             case "task":
-                logger.info(f"Updating mission status in data service")
+                logger.info("Updating mission status in data service")
                 await self.update_mission_status(req)
             case None:
                 raise Exception("Expected at least one request type")

--- a/vehicle/hub/data_service.py
+++ b/vehicle/hub/data_service.py
@@ -10,14 +10,17 @@ from service import Service
 from util.utils import SocketOperation, setup_logging
 
 logger = logging.getLogger(__name__)
-setup_logging(logger, 'hub.logging')
+setup_logging(logger, "hub.logging")
+
 
 # Bandaid fix to prevent logs from being polluted by WRONG_INPUT_FORMAT errors.
 class WrongInputFormatFilter(logging.Filter):
     def filter(self, record):
         return "WRONG_INPUT_FORMAT" not in record.getMessage()
 
-logging.getLogger('gabriel_client.zeromq_client').addFilter(WrongInputFormatFilter())
+
+logging.getLogger("gabriel_client.zeromq_client").addFilter(WrongInputFormatFilter())
+
 
 class DataService(Service):
     def __init__(self, data_store: DataStore, compute_dict):
@@ -31,20 +34,26 @@ class DataService(Service):
         self.cam_sock = self.context.socket(zmq.SUB)
         self.data_reply_sock = self.context.socket(zmq.DEALER)
 
-        self.tel_sock.setsockopt(zmq.SUBSCRIBE, b'')  # Subscribe to all topics
+        self.tel_sock.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics
         self.tel_sock.setsockopt(zmq.CONFLATE, 1)
-        self.cam_sock.setsockopt(zmq.SUBSCRIBE, b'')  # Subscribe to all topics
+        self.cam_sock.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics
         self.cam_sock.setsockopt(zmq.CONFLATE, 1)
 
         self.setup_and_register_socket(
-            self.tel_sock, SocketOperation.BIND,
-            'hub.network.dataplane.driver_to_hub.telemetry')
+            self.tel_sock,
+            SocketOperation.BIND,
+            "hub.network.dataplane.driver_to_hub.telemetry",
+        )
         self.setup_and_register_socket(
-            self.cam_sock, SocketOperation.BIND,
-            'hub.network.dataplane.driver_to_hub.image_sensor')
+            self.cam_sock,
+            SocketOperation.BIND,
+            "hub.network.dataplane.driver_to_hub.image_sensor",
+        )
         self.setup_and_register_socket(
-            self.data_reply_sock, SocketOperation.BIND,
-            'hub.network.dataplane.mission_to_hub')
+            self.data_reply_sock,
+            SocketOperation.BIND,
+            "hub.network.dataplane.mission_to_hub",
+        )
 
         # Unified poller task
         self.create_task(self.data_proxy())

--- a/vehicle/hub/data_store.py
+++ b/vehicle/hub/data_store.py
@@ -1,10 +1,11 @@
 import asyncio
-from dataclasses import dataclass
-from google.protobuf import timestamp_pb2
-import dataplane_pb2 as data_protocol
-from typing import Optional, Union
-import time
 import logging
+import time
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import dataplane_pb2 as data_protocol
+from google.protobuf import timestamp_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/hub/data_store.py
+++ b/vehicle/hub/data_store.py
@@ -66,7 +66,7 @@ class DataStore:
         result = cache.get(type)
         if result is None:
             # Log an error and return None
-            logger.error(f"get_compute_result: No result found for {compute_id=} and {type=}")
+            logger.debug(f"get_compute_result: No result found for {compute_id=} and {type=}")
             return None
 
         return result
@@ -121,11 +121,12 @@ class DataStore:
         entry.timestamp = time.monotonic()
         if data_type in self._raw_data_event:
             self._raw_data_event[data_type].set()
-    
+
     def update_current_task(self, task_type):
         if data_protocol.Telemetry not in self._raw_data_cache:
             logger.error(f"update_current_task: Telemetry type not in data cache")
         else:
+            logger.info(f"Setting current task to {task_type}")
             entry = self._raw_data_cache[data_protocol.Telemetry]
             entry.data.current_task = task_type
             entry.timestamp = time.monotonic()

--- a/vehicle/hub/data_store.py
+++ b/vehicle/hub/data_store.py
@@ -124,7 +124,7 @@ class DataStore:
 
     def update_current_task(self, task_type):
         if data_protocol.Telemetry not in self._raw_data_cache:
-            logger.error(f"update_current_task: Telemetry type not in data cache")
+            logger.error("update_current_task: Telemetry type not in data cache")
         else:
             logger.info(f"Setting current task to {task_type}")
             entry = self._raw_data_cache[data_protocol.Telemetry]

--- a/vehicle/hub/data_store.py
+++ b/vehicle/hub/data_store.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from typing import Optional, Union
 
 import dataplane_pb2 as data_protocol
 from google.protobuf import timestamp_pb2
@@ -23,8 +22,8 @@ class ComputeResult:
 class RawDataEntry:
     """Class representing raw data entries"""
 
-    data: Union[data_protocol.Frame, data_protocol.Telemetry, None]
-    data_id: Optional[int]
+    data: data_protocol.Frame | data_protocol.Telemetry | None
+    data_id: int | None
     timestamp: float
 
 
@@ -59,7 +58,7 @@ class DataStore:
     ###########################################################################
     #                               COMPUTE                                   #
     ###########################################################################
-    def get_compute_result(self, compute_id, type) -> Optional[ComputeResult]:
+    def get_compute_result(self, compute_id, type) -> ComputeResult | None:
         logger.debug(
             f"get_compute_result: Getting result for compute {compute_id} with type {type}"
         )

--- a/vehicle/hub/data_store.py
+++ b/vehicle/hub/data_store.py
@@ -9,19 +9,24 @@ from google.protobuf import timestamp_pb2
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class ComputeResult:
     """Class representing a compute result"""
+
     data: str
     frame_id: int
     timestamp: timestamp_pb2.Timestamp
 
+
 @dataclass
 class RawDataEntry:
     """Class representing raw data entries"""
+
     data: Union[data_protocol.Frame, data_protocol.Telemetry, None]
     data_id: Optional[int]
     timestamp: float
+
 
 class DataStore:
     def __init__(self):
@@ -40,10 +45,14 @@ class DataStore:
 
     def clear_compute_result(self, compute_id, compute_type):
         """Clears the compute result for a given compute ID and type."""
-        logger.info(f"clear_compute_result: Clearing result for {compute_id=} and {compute_type=}")
+        logger.info(
+            f"clear_compute_result: Clearing result for {compute_id=} and {compute_type=}"
+        )
         if compute_id in self._result_cache:
             self._result_cache[compute_id].pop(compute_type, None)
-            logger.debug(f"clear_compute_result: Cleared result for {compute_id=} and {compute_type=}")
+            logger.debug(
+                f"clear_compute_result: Cleared result for {compute_id=} and {compute_type=}"
+            )
         else:
             logger.error(f"clear_compute_result: No such compute ID: {compute_id=}")
 
@@ -51,7 +60,9 @@ class DataStore:
     #                               COMPUTE                                   #
     ###########################################################################
     def get_compute_result(self, compute_id, type) -> Optional[ComputeResult]:
-        logger.debug(f"get_compute_result: Getting result for compute {compute_id} with type {type}")
+        logger.debug(
+            f"get_compute_result: Getting result for compute {compute_id} with type {type}"
+        )
         logger.debug(self._result_cache)
         if compute_id not in self._result_cache:
             # Log an error and return None
@@ -67,7 +78,9 @@ class DataStore:
         result = cache.get(type)
         if result is None:
             # Log an error and return None
-            logger.debug(f"get_compute_result: No result found for {compute_id=} and {type=}")
+            logger.debug(
+                f"get_compute_result: No result found for {compute_id=} and {type=}"
+            )
             return None
 
         return result
@@ -76,9 +89,15 @@ class DataStore:
         self._result_cache[compute_id] = {}
 
     def update_compute_result(self, compute_id, type: str, result, frame_id, timestamp):
-        assert isinstance(type, str), f"Argument must be a string, got {type(type).__name__}"
-        self._result_cache[compute_id][type] = ComputeResult(result, frame_id, timestamp)
-        logger.debug(f"update_compute_result: Updated result cache for {compute_id=} and {type=}; result: {result}")
+        assert isinstance(type, str), (
+            f"Argument must be a string, got {type(type).__name__}"
+        )
+        self._result_cache[compute_id][type] = ComputeResult(
+            result, frame_id, timestamp
+        )
+        logger.debug(
+            f"update_compute_result: Updated result cache for {compute_id=} and {type=}; result: {result}"
+        )
 
     ###########################################################################
     #                                RAW DATA                                 #
@@ -101,7 +120,7 @@ class DataStore:
 
         return cache
 
-    def set_raw_data(self, data, data_id = None):
+    def set_raw_data(self, data, data_id=None):
         data_type = type(data)
 
         if data_type not in self._raw_data_cache:
@@ -109,7 +128,9 @@ class DataStore:
             return None
 
         if self._raw_data_cache[data_type] is None:
-            self._raw_data_cache[data_type] = RawDataEntry(data, data_id, time.monotonic())
+            self._raw_data_cache[data_type] = RawDataEntry(
+                data, data_id, time.monotonic()
+            )
 
         entry = self._raw_data_cache[data_type]
 
@@ -138,4 +159,3 @@ class DataStore:
             return None
         self._raw_data_event[data_type].clear()
         await self._raw_data_event[data_type].wait()
-

--- a/vehicle/hub/service.py
+++ b/vehicle/hub/service.py
@@ -8,6 +8,7 @@ from util.utils import setup_socket
 
 logger = logging.getLogger(__name__)
 
+
 class Service(ABC):
     def __init__(self):
         self.tasks = []
@@ -19,7 +20,9 @@ class Service(ABC):
         self.tasks.append(task)
         return task
 
-    def setup_and_register_socket(self, socket, socket_op, socket_id=None, port=None, host_addr="*"):
+    def setup_and_register_socket(
+        self, socket, socket_op, socket_id=None, port=None, host_addr="*"
+    ):
         setup_socket(socket, socket_op, socket_id, port, host_addr)
         self.socks.append(socket)
 
@@ -31,7 +34,7 @@ class Service(ABC):
             await self.shutdown()
 
     async def shutdown(self):
-        logger.info(f'{self.__class__.__name__}: Shutting down Service')
+        logger.info(f"{self.__class__.__name__}: Shutting down Service")
         for sock in self.socks:
             sock.close()
 
@@ -52,8 +55,4 @@ class Service(ABC):
                 except Exception as err:
                     logger.error(f"Task raised exception: {err}")
 
-
         logger.info("Main: Service shutdown complete")
-
-
-

--- a/vehicle/hub/service.py
+++ b/vehicle/hub/service.py
@@ -1,9 +1,10 @@
-from abc import ABC
 import asyncio
 import logging
-from util.utils import setup_socket
+from abc import ABC
+
 import zmq
 import zmq.asyncio
+from util.utils import setup_socket
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/mission/core/MissionController.py
+++ b/vehicle/mission/core/MissionController.py
@@ -162,7 +162,7 @@ class MissionController():
                     self.current_task = self.tm.get_current_task_type()
                 else:
                     self.current_task = "idle"
-                
+
                 # Receive a message
                 message = self.msn_control_sock.recv(flags=zmq.NOBLOCK)
 
@@ -195,7 +195,7 @@ class MissionController():
 
                 else:
                     resp = common_protocol.ResponseStatus.NOTSUPPORTED
-                
+
                 # Send a reply back to the client
                 rep = control_protocol.Response()
                 rep.resp = resp
@@ -206,7 +206,7 @@ class MissionController():
             except zmq.Again:
                 pass
             except Exception as e:
-                logger.info(f"Failed to parse message: {e}")
+                logger.error(f"Failed to parse message: {e}")
                 resp = common_protocol.ResponseStatus.FAILED
 
                 # Send a reply back to the client

--- a/vehicle/mission/core/MissionController.py
+++ b/vehicle/mission/core/MissionController.py
@@ -1,22 +1,21 @@
 
+import asyncio
 import importlib
+import logging
 import os
-import subprocess
 import shutil
+import subprocess
 import sys
 from zipfile import ZipFile
+
+import common_pb2 as common_protocol
+import controlplane_pb2 as control_protocol
 import requests
 import zmq
-import asyncio
-import logging
-from util.utils import SocketOperation, setup_socket
 from system_call_stubs.control_stub import ControlStub
 from system_call_stubs.data_stub import DataStub
 from system_call_stubs.report_stub import ReportStub
-import controlplane_pb2 as control_protocol
-import common_pb2 as common_protocol
-
-
+from util.utils import SocketOperation, setup_socket
 
 logger = logging.getLogger(__name__)
 context = zmq.Context()
@@ -120,7 +119,7 @@ class MissionController():
         if self.reload :
             self.reload_mission()
 
-        import project.Mission as msn # import the mission module instead of attribute of the module for the reload to work
+        import project.Mission as msn  # import the mission module instead of attribute of the module for the reload to work
         self.reload = True
 
         msn.Mission.define_mission(self.transitMap, self.task_arg_map)

--- a/vehicle/mission/core/MissionController.py
+++ b/vehicle/mission/core/MissionController.py
@@ -9,7 +9,7 @@ import requests
 import zmq
 import asyncio
 import logging
-from util.utils import SocketOperation, setup_socket, setup_logging
+from util.utils import SocketOperation, setup_socket
 from system_call_stubs.control_stub import ControlStub
 from system_call_stubs.data_stub import DataStub
 from system_call_stubs.report_stub import ReportStub
@@ -111,12 +111,12 @@ class MissionController():
 
     def start_mission(self):
         if self.tm:
-            logger.info(f"mission already running")
+            logger.info("mission already running")
             return
         else: # first time mission, create a task manager
             import core.TaskManager as tm
 
-        logger.info(f"start the mission")
+        logger.info("start the mission")
         if self.reload :
             self.reload_mission()
 
@@ -126,7 +126,7 @@ class MissionController():
         msn.Mission.define_mission(self.transitMap, self.task_arg_map)
 
         # start the tm
-        logger.info(f"start the task manager")
+        logger.info("start the task manager")
         self.tm = tm.TaskManager(self.ctrl, self.data, self.transitMap, self.task_arg_map)
         self.tm_coroutine = asyncio.create_task(self.tm.run())
 

--- a/vehicle/mission/core/TaskManager.py
+++ b/vehicle/mission/core/TaskManager.py
@@ -1,10 +1,11 @@
 import asyncio
 import logging
+
 import interface.Task as taskitf
-import project.task_defs.TrackTask as track
-import project.task_defs.DetectTask as detect
 import project.task_defs.AvoidTask as avoid
+import project.task_defs.DetectTask as detect
 import project.task_defs.TestTask as test
+import project.task_defs.TrackTask as track
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/mission/core/TaskManager.py
+++ b/vehicle/mission/core/TaskManager.py
@@ -22,13 +22,13 @@ class TaskManager:
 
     def get_current_task(self):
         return self.curr_task_id
-    
+
     def get_current_task_type(self):
         task_id = self.get_current_task()
         if task_id in self.task_arg_map:
             return self.task_arg_map[task_id].task_type.name
         else:
-            logger.error(f"Failed to find current task in arg map. Task ID: {task_id}")
+            logger.debug(f"Failed to find current task in arg map. Task ID: {task_id}")
             return None
 
     def retrieve_next_task(self, current_task_id, triggered_event):
@@ -63,7 +63,7 @@ class TaskManager:
         self.currentTask = task
         self.taskCurrentCoroutine = asyncio.create_task(task.run())
         self.curr_task_id = task.task_id
-        self.compute.update_current_task(self.get_current_task_type())
+        await self.compute.update_current_task(self.get_current_task_type())
 
     def create_task(self, task_id):
         logger.info(f"Creating task with task_id {task_id}")
@@ -111,7 +111,7 @@ class TaskManager:
                     next_task = self.create_task(next_task_id)
                     if next_task:
                         await self.transit_task_to(next_task)
-                    self.compute.update_current_task(self.get_current_task_type())
+                    await self.compute.update_current_task(self.get_current_task_type())
                 await asyncio.sleep(0)
 
         except Exception as e:

--- a/vehicle/mission/core/TaskManager.py
+++ b/vehicle/mission/core/TaskManager.py
@@ -9,6 +9,7 @@ import project.task_defs.TrackTask as track
 
 logger = logging.getLogger(__name__)
 
+
 class TaskManager:
     def __init__(self, drone, compute, transit_map, task_arg_map):
         self.trigger_event_queue = asyncio.Queue()
@@ -33,7 +34,9 @@ class TaskManager:
             return None
 
     def retrieve_next_task(self, current_task_id, triggered_event):
-        logger.info(f"next task, current_task_id {current_task_id}, trigger_event {triggered_event}")
+        logger.info(
+            f"next task, current_task_id {current_task_id}, trigger_event {triggered_event}"
+        )
         try:
             next_task_id = self.transit_map.get(current_task_id)(triggered_event)
         except Exception as e:
@@ -54,7 +57,9 @@ class TaskManager:
                 except asyncio.CancelledError:
                     logger.info(f"Task {self.curr_task_id} cancelled successfully")
 
-            logger.info(f"Clearing currentTask reference for task_id {self.curr_task_id}")
+            logger.info(
+                f"Clearing currentTask reference for task_id {self.curr_task_id}"
+            )
             self.currentTask = None
             self.taskCurrentCoroutine = None
             self.curr_task_id = None
@@ -71,13 +76,37 @@ class TaskManager:
         if task_id in self.task_arg_map:
             task_args = self.task_arg_map[task_id]
             if task_args.task_type == taskitf.TaskType.Detect:
-                return detect.DetectTask(self.drone, self.compute, task_id, self.trigger_event_queue, task_args)
+                return detect.DetectTask(
+                    self.drone,
+                    self.compute,
+                    task_id,
+                    self.trigger_event_queue,
+                    task_args,
+                )
             elif task_args.task_type == taskitf.TaskType.Track:
-                return track.TrackTask(self.drone, self.compute, task_id, self.trigger_event_queue, task_args)
+                return track.TrackTask(
+                    self.drone,
+                    self.compute,
+                    task_id,
+                    self.trigger_event_queue,
+                    task_args,
+                )
             elif task_args.task_type == taskitf.TaskType.Avoid:
-                return avoid.AvoidTask(self.drone, self.compute, task_id, self.trigger_event_queue, task_args)
+                return avoid.AvoidTask(
+                    self.drone,
+                    self.compute,
+                    task_id,
+                    self.trigger_event_queue,
+                    task_args,
+                )
             elif task_args.task_type == taskitf.TaskType.Test:
-                return test.TestTask(self.drone, self.compute, task_id, self.trigger_event_queue, task_args)
+                return test.TestTask(
+                    self.drone,
+                    self.compute,
+                    task_id,
+                    self.trigger_event_queue,
+                    task_args,
+                )
         logger.warning(f"No matching task found for task_id {task_id}")
         return None
 
@@ -90,7 +119,9 @@ class TaskManager:
                 await self.start_task(start_task)
 
     async def transit_task_to(self, task):
-        logger.info(f"Transiting to task with task_id: {task.task_id}, current_task_id: {self.curr_task_id}")
+        logger.info(
+            f"Transiting to task with task_id: {task.task_id}, current_task_id: {self.curr_task_id}"
+        )
         await self.stop_task()
         await self.start_task(task)
 
@@ -101,7 +132,9 @@ class TaskManager:
 
             while True:
                 task_id, trigger_event = await self.trigger_event_queue.get()
-                logger.info(f"Triggered event: task_id {task_id}, event {trigger_event}")
+                logger.info(
+                    f"Triggered event: task_id {task_id}, event {trigger_event}"
+                )
 
                 if task_id == self.get_current_task():
                     next_task_id = self.retrieve_next_task(task_id, trigger_event)

--- a/vehicle/mission/core/__main__.py
+++ b/vehicle/mission/core/__main__.py
@@ -6,13 +6,13 @@ from MissionController import MissionController
 from util.utils import setup_logging
 
 logger = logging.getLogger()
-setup_logging(logger, 'mission.logging')
+setup_logging(logger, "mission.logging")
 
 
 logger.info("Starting the usr space")
 current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir)
-project_dir = os.path.join(parent_dir, 'project')
+project_dir = os.path.join(parent_dir, "project")
 logger.info("proj_path: %s", project_dir)
 
 mc = MissionController(project_dir)

--- a/vehicle/mission/core/__main__.py
+++ b/vehicle/mission/core/__main__.py
@@ -2,6 +2,7 @@ import  asyncio
 import logging
 import os
 from util.utils import setup_logging
+from MissionController import MissionController
 
 logger = logging.getLogger()
 setup_logging(logger, 'mission.logging')
@@ -13,7 +14,6 @@ parent_dir = os.path.dirname(current_dir)
 project_dir = os.path.join(parent_dir, 'project')
 logger.info("proj_path: %s", project_dir)
 
-from MissionController import MissionController
 mc = MissionController(project_dir)
 asyncio.run(mc.run())
 print("Mission controller is done")

--- a/vehicle/mission/core/__main__.py
+++ b/vehicle/mission/core/__main__.py
@@ -1,8 +1,9 @@
-import  asyncio
+import asyncio
 import logging
 import os
-from util.utils import setup_logging
+
 from MissionController import MissionController
+from util.utils import setup_logging
 
 logger = logging.getLogger()
 setup_logging(logger, 'mission.logging')

--- a/vehicle/mission/system_call_stubs/control_stub.py
+++ b/vehicle/mission/system_call_stubs/control_stub.py
@@ -137,7 +137,7 @@ class ControlStub(Stub):
             return False
         return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
 
-    async def set_gimbal_pose(self, pitch, roll, yaw, mode='POSITION_ABSOLUTE'):
+    async def set_gimbal_pose(self, pitch, roll, yaw, mode='ABSOLUTE'):
         request = control_protocol.Request()
         request.veh.gimbal_pose.pitch = pitch
         request.veh.gimbal_pose.roll = roll

--- a/vehicle/mission/system_call_stubs/control_stub.py
+++ b/vehicle/mission/system_call_stubs/control_stub.py
@@ -1,5 +1,3 @@
-import ast
-import json
 import logging
 from system_call_stubs.stub import Stub
 import controlplane_pb2 as control_protocol
@@ -160,7 +158,7 @@ class ControlStub(Stub):
 
     ''' Compute methods '''
     async def clear_compute_result(self, compute_type):
-        logger.info(f"clearing compute result")
+        logger.info("clearing compute result")
         cpt_req = control_protocol.Request()
         cpt_req.cpt.type = compute_type
         cpt_req.cpt.action = control_protocol.ComputeAction.CLEAR_COMPUTE

--- a/vehicle/mission/system_call_stubs/control_stub.py
+++ b/vehicle/mission/system_call_stubs/control_stub.py
@@ -55,23 +55,30 @@ class ControlStub(Stub):
             return False
         return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
 
-    async def set_gps_location(self, latitude, longitude, altitude, bearing, altitude_mode='ABSOLUTE', heading_mode='TO_TARGET', velocity=(0, 0, 0)):
+    async def set_gps_location(self, latitude, longitude, altitude, bearing=0, altitude_mode='RELATIVE', heading_mode='TO_TARGET', velocity=(0, 0, 0)):
         request = control_protocol.Request()
         request.veh.location.latitude = latitude
         request.veh.location.longitude = longitude
         request.veh.location.altitude = altitude
+        request.veh.location.heading = bearing
         if altitude_mode == 'ABSOLUTE':
-            request.veh.location.heading_mode = \
+            request.veh.location.altitude_mode = \
                 common_protocol.LocationAltitudeMode.ABSOLUTE
-        else:
-            request.veh.location.heading_mode = \
+        elif altitude_mode == 'RELATIVE':
+            request.veh.location.altitude_mode = \
                 common_protocol.LocationAltitudeMode.TAKEOFF_RELATIVE
+        else:
+            logger.error("Invalid altitude mode")
+            return False
         if heading_mode == 'TO_TARGET':
             request.veh.location.heading_mode = \
                 common_protocol.LocationHeadingMode.TO_TARGET
-        else:
+        elif heading_mode == 'HEADING_START':
             request.veh.location.heading_mode = \
                 common_protocol.LocationHeadingMode.HEADING_START
+        else:
+            logger.error("Invalid heading mode")
+            return False
         request.veh.location.max_velocity.north_vel = velocity[0]
         request.veh.location.max_velocity.east_vel = velocity[0]
         request.veh.location.max_velocity.up_vel = velocity[1]

--- a/vehicle/mission/system_call_stubs/control_stub.py
+++ b/vehicle/mission/system_call_stubs/control_stub.py
@@ -7,10 +7,10 @@ from system_call_stubs.stub import Stub
 
 logger = logging.getLogger(__name__)
 
-class ControlStub(Stub):
 
+class ControlStub(Stub):
     def __init__(self):
-        super().__init__(b'usr', 'hub.network.controlplane.mission_to_hub', 'control')
+        super().__init__(b"usr", "hub.network.controlplane.mission_to_hub", "control")
 
     def parse_control_response(self, response_parts):
         self.parse_response(response_parts, control_protocol.Response)
@@ -18,7 +18,8 @@ class ControlStub(Stub):
     async def run(self):
         await self.receiver_loop(self.parse_control_response)
 
-    ''' Vehicle methods '''
+    """ Vehicle methods """
+
     async def take_off(self):
         request = control_protocol.Request()
         request.veh.action = control_protocol.VehicleAction.TAKEOFF
@@ -26,7 +27,9 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Takeoff failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def land(self):
         request = control_protocol.Request()
@@ -35,7 +38,9 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Landing failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def rth(self):
         request = control_protocol.Request()
@@ -44,7 +49,9 @@ class ControlStub(Stub):
         if result is None:
             logger.error("RTH failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def hover(self):
         request = control_protocol.Request()
@@ -53,29 +60,44 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Hover failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
-    async def set_gps_location(self, latitude, longitude, altitude, bearing=0, altitude_mode='RELATIVE', heading_mode='TO_TARGET', velocity=(0, 0, 0)):
+    async def set_gps_location(
+        self,
+        latitude,
+        longitude,
+        altitude,
+        bearing=0,
+        altitude_mode="RELATIVE",
+        heading_mode="TO_TARGET",
+        velocity=(0, 0, 0),
+    ):
         request = control_protocol.Request()
         request.veh.location.latitude = latitude
         request.veh.location.longitude = longitude
         request.veh.location.altitude = altitude
         request.veh.location.heading = bearing
-        if altitude_mode == 'ABSOLUTE':
-            request.veh.location.altitude_mode = \
+        if altitude_mode == "ABSOLUTE":
+            request.veh.location.altitude_mode = (
                 common_protocol.LocationAltitudeMode.ABSOLUTE
-        elif altitude_mode == 'RELATIVE':
-            request.veh.location.altitude_mode = \
+            )
+        elif altitude_mode == "RELATIVE":
+            request.veh.location.altitude_mode = (
                 common_protocol.LocationAltitudeMode.TAKEOFF_RELATIVE
+            )
         else:
             logger.error("Invalid altitude mode")
             return False
-        if heading_mode == 'TO_TARGET':
-            request.veh.location.heading_mode = \
+        if heading_mode == "TO_TARGET":
+            request.veh.location.heading_mode = (
                 common_protocol.LocationHeadingMode.TO_TARGET
-        elif heading_mode == 'HEADING_START':
-            request.veh.location.heading_mode = \
+            )
+        elif heading_mode == "HEADING_START":
+            request.veh.location.heading_mode = (
                 common_protocol.LocationHeadingMode.HEADING_START
+            )
         else:
             logger.error("Invalid heading mode")
             return False
@@ -87,7 +109,9 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Setting GPS location failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def set_relative_position_enu(self, north, east, up, angle):
         request = control_protocol.Request()
@@ -99,7 +123,9 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Setting relative position ENU failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def set_relative_position_body(self, forward, right, up, angle):
         request = control_protocol.Request()
@@ -111,7 +137,9 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Setting relative position body failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def set_velocity_enu(self, north_vel, east_vel, up_vel, angle_vel):
         request = control_protocol.Request()
@@ -123,7 +151,9 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Setting velocity ENU failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def set_velocity_body(self, forward_vel, right_vel, up_vel, angle_vel):
         request = control_protocol.Request()
@@ -135,30 +165,38 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Setting velocity body failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
-    async def set_gimbal_pose(self, pitch, roll, yaw, mode='ABSOLUTE'):
+    async def set_gimbal_pose(self, pitch, roll, yaw, mode="ABSOLUTE"):
         request = control_protocol.Request()
         request.veh.gimbal_pose.pitch = pitch
         request.veh.gimbal_pose.roll = roll
         request.veh.gimbal_pose.yaw = yaw
-        if mode == 'ABSOLUTE':
-            request.veh.gimbal_pose.control_mode = \
+        if mode == "ABSOLUTE":
+            request.veh.gimbal_pose.control_mode = (
                 common_protocol.PoseControlMode.POSITION_ABSOLUTE
-        elif mode == 'RELATIVE':
-            request.veh.gimbal_pose.control_mode = \
+            )
+        elif mode == "RELATIVE":
+            request.veh.gimbal_pose.control_mode = (
                 common_protocol.PoseControlMode.POSITION_RELATIVE
+            )
         else:
-            request.veh.gimbal_pose.control_mode = \
+            request.veh.gimbal_pose.control_mode = (
                 common_protocol.PoseControlMode.VELOCITY
+            )
 
         result = await self.send_and_wait(request)
         if result is None:
             logger.error("Setting gimbal pose failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
-    ''' Compute methods '''
+    """ Compute methods """
+
     async def clear_compute_result(self, compute_type):
         logger.info("clearing compute result")
         cpt_req = control_protocol.Request()
@@ -168,11 +206,15 @@ class ControlStub(Stub):
         if result is None:
             logger.error("Clearing compute result failed: No response received")
             return False
-        return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        return (
+            True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+        )
 
     async def configure_compute(self, compute_model, hsv_lower_bound, hsv_upper_bound):
         try:
-            logger.info(f"configuring compute model: {compute_model}, lower bound: {hsv_lower_bound}, upper bound: {hsv_upper_bound}")
+            logger.info(
+                f"configuring compute model: {compute_model}, lower bound: {hsv_lower_bound}, upper bound: {hsv_upper_bound}"
+            )
             cpt_req = control_protocol.Request()
             cpt_req.cpt.lower_bound.h = hsv_lower_bound[0]
             cpt_req.cpt.lower_bound.s = hsv_lower_bound[1]
@@ -186,6 +228,10 @@ class ControlStub(Stub):
             if result is None:
                 logger.error("Configure compute failed: No response received")
                 return False
-            return True if result.resp == common_protocol.ResponseStatus.COMPLETED else False
+            return (
+                True
+                if result.resp == common_protocol.ResponseStatus.COMPLETED
+                else False
+            )
         except Exception as e:
             logger.info(f"{e}")

--- a/vehicle/mission/system_call_stubs/control_stub.py
+++ b/vehicle/mission/system_call_stubs/control_stub.py
@@ -1,7 +1,9 @@
 import logging
-from system_call_stubs.stub import Stub
-import controlplane_pb2 as control_protocol
+
 import common_pb2 as common_protocol
+import controlplane_pb2 as control_protocol
+
+from system_call_stubs.stub import Stub
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/mission/system_call_stubs/data_stub.py
+++ b/vehicle/mission/system_call_stubs/data_stub.py
@@ -7,7 +7,7 @@ from system_call_stubs.stub import Stub
 import dataplane_pb2 as data_protocol
 
 logger = logging.getLogger(__name__)
-        
+
 class DataStub(Stub):
     def __init__(self):
         super().__init__(b'usr', 'hub.network.dataplane.mission_to_hub', 'data')
@@ -17,83 +17,85 @@ class DataStub(Stub):
 
     async def run(self):
         await self.receiver_loop(self.parse_data_response)
-    
+
     ''' Compute methods '''
     # Get results for a compute engine
     async def get_compute_result(self, compute_type):
         cpt_req = data_protocol.Request()
         cpt_req.cpt.type = compute_type
         rep = await self.send_and_wait(cpt_req)
-        
+
         if rep is None:
             logger.error(f"Failed to get compute result: No response received for {compute_type=}")
             return None
-        
+
         result_list = []
         for result in rep.cpt.result:
             result_list.append(result.generic_result)
-            
+
         logger.debug(f"get_compute_result: {compute_type=}, {result_list=}")
         return result_list
 
     ''' Telemetry methods '''
     async def get_telemetry(self):
-        request = data_protocol.Request(tel=data_protocol.TelemetryRequest())
-        rep = await self.send_and_wait(request)
-        
-        if rep is None:
-            logger.error("Failed to get telemetry: No response received")
-            return None
-        
-        result = rep.tel
-        tel_dict = {
-            "drone_name": None,
-            "global_position": {"latitude": None, "longitude": None, "heading": None, \
-                    "altitude": None, "relative_altitude": None},
-            "relative_position": {"north": None, "east": None, "up": None},
-            "velocity_enu": {"north": None, "east": None, "up": None},
-            "velocity_body": {"forward": None, "right": None, "up": None},
-            "gimbal_pose": {"yaw": None, "pitch": None, "roll": None},
-            "home": {"latitude": None, "longitude": None, "altitude": None},
-            "cameras": {},
-            "alerts": {},
-            "battery": None,
-            "satellites": None,
-            "status": None,
-            "current_task": None
-        }
-        if result:
-            # Name
-            tel_dict["drone_name"] = result.drone_name
-            # Global Position
-            tel_dict["global_position"]["latitude"] = result.global_position.latitude
-            tel_dict["global_position"]["longitude"] = result.global_position.longitude
-            tel_dict["global_position"]["altitude"] = result.global_position.absolute_altitude
-            tel_dict["global_position"]["relative_altitude"] = result.global_position.relative_altitude
-            tel_dict["global_position"]["heading"] = result.global_position.heading
-            # Velocity Body
-            tel_dict["velocity_body"]["forward"] = result.velocity_body.forward_vel
-            tel_dict["velocity_body"]["right"] = result.velocity_body.right_vel
-            tel_dict["velocity_body"]["up"] = result.velocity_body.up_vel
-            # Gimbal
-            tel_dict["gimbal_pose"]["yaw"] = result.gimbal_pose.yaw
-            tel_dict["gimbal_pose"]["pitch"] = result.gimbal_pose.pitch
-            tel_dict["gimbal_pose"]["roll"] = result.gimbal_pose.roll
-            # Battery & Satellites
-            tel_dict["battery"] = result.battery
-            tel_dict["satellites"] = result.satellites
-            # Status & Current Mission Task
-            tel_dict["status"] = result.status
-            tel_dict["current_task"] = result.current_task
-            
-            return tel_dict
-        else:
-            logger.error("Failed to get telemetry")    
-            return None
+        try:
+            request = data_protocol.Request(tel=data_protocol.TelemetryRequest())
+            rep = await self.send_and_wait(request)
 
-    async def send_mission_status(self, current_task):
-        tel = data_protocol.TelemetryRequest()
-        tel.current_task = current_task
-        rep = await self.send_and_wait(tel)
+            if rep is None:
+                logger.error("Failed to get telemetry: No response received")
+                return None
+
+            result = rep.tel
+            tel_dict = {
+                "drone_name": None,
+                "global_position": {"latitude": None, "longitude": None, "heading": None, \
+                        "altitude": None, "relative_altitude": None},
+                "relative_position": {"north": None, "east": None, "up": None},
+                "velocity_enu": {"north": None, "east": None, "up": None},
+                "velocity_body": {"forward": None, "right": None, "up": None},
+                "gimbal_pose": {"yaw": None, "pitch": None, "roll": None},
+                "home": {"latitude": None, "longitude": None, "altitude": None},
+                "cameras": {},
+                "alerts": {},
+                "battery": None,
+                "satellites": None,
+                "status": None,
+            }
+            if result:
+                # Name
+                tel_dict["drone_name"] = result.drone_name
+                # Global Position
+                tel_dict["global_position"]["latitude"] = result.global_position.latitude
+                tel_dict["global_position"]["longitude"] = result.global_position.longitude
+                tel_dict["global_position"]["altitude"] = result.global_position.altitude
+                tel_dict["global_position"]["relative_altitude"] = result.relative_position.up
+                tel_dict["global_position"]["heading"] = result.global_position.heading
+                # Velocity Body
+                tel_dict["velocity_body"]["forward"] = result.velocity_body.forward_vel
+                tel_dict["velocity_body"]["right"] = result.velocity_body.right_vel
+                tel_dict["velocity_body"]["up"] = result.velocity_body.up_vel
+                # Gimbal
+                tel_dict["gimbal_pose"]["yaw"] = result.gimbal_pose.yaw
+                tel_dict["gimbal_pose"]["pitch"] = result.gimbal_pose.pitch
+                tel_dict["gimbal_pose"]["roll"] = result.gimbal_pose.roll
+                # Battery & Satellites
+                tel_dict["battery"] = result.battery
+                tel_dict["satellites"] = result.satellites
+                # Status
+                tel_dict["status"] = result.status
+
+                return tel_dict
+            else:
+                logger.error("Failed to get telemetry")
+                return None
+        except Exception as e:
+            logger.error(e)
+
+    async def update_current_task(self, current_task):
+        logger.info("Updating current task")
+        req = data_protocol.Request(task=data_protocol.UpdateCurrentTask(task_name=current_task))
+        rep = await self.send_and_wait(req)
+        logger.info(f"Got response {rep}")
         if rep is None:
             logger.error("Failed to send mission status")

--- a/vehicle/mission/system_call_stubs/data_stub.py
+++ b/vehicle/mission/system_call_stubs/data_stub.py
@@ -10,9 +10,10 @@ from system_call_stubs.stub import Stub
 
 logger = logging.getLogger(__name__)
 
+
 class DataStub(Stub):
     def __init__(self):
-        super().__init__(b'usr', 'hub.network.dataplane.mission_to_hub', 'data')
+        super().__init__(b"usr", "hub.network.dataplane.mission_to_hub", "data")
 
     def parse_data_response(self, response_parts):
         self.parse_response(response_parts, data_protocol.Response)
@@ -20,7 +21,8 @@ class DataStub(Stub):
     async def run(self):
         await self.receiver_loop(self.parse_data_response)
 
-    ''' Compute methods '''
+    """ Compute methods """
+
     # Get results for a compute engine
     async def get_compute_result(self, compute_type):
         cpt_req = data_protocol.Request()
@@ -28,7 +30,9 @@ class DataStub(Stub):
         rep = await self.send_and_wait(cpt_req)
 
         if rep is None:
-            logger.error(f"Failed to get compute result: No response received for {compute_type=}")
+            logger.error(
+                f"Failed to get compute result: No response received for {compute_type=}"
+            )
             return None
 
         result_list = []
@@ -38,7 +42,8 @@ class DataStub(Stub):
         logger.debug(f"get_compute_result: {compute_type=}, {result_list=}")
         return result_list
 
-    ''' Telemetry methods '''
+    """ Telemetry methods """
+
     async def get_telemetry(self):
         try:
             request = data_protocol.Request(tel=data_protocol.TelemetryRequest())
@@ -51,8 +56,13 @@ class DataStub(Stub):
             result = rep.tel
             tel_dict = {
                 "drone_name": None,
-                "global_position": {"latitude": None, "longitude": None, "heading": None, \
-                        "altitude": None, "relative_altitude": None},
+                "global_position": {
+                    "latitude": None,
+                    "longitude": None,
+                    "heading": None,
+                    "altitude": None,
+                    "relative_altitude": None,
+                },
                 "relative_position": {"north": None, "east": None, "up": None},
                 "velocity_enu": {"north": None, "east": None, "up": None},
                 "velocity_body": {"forward": None, "right": None, "up": None},
@@ -68,10 +78,18 @@ class DataStub(Stub):
                 # Name
                 tel_dict["drone_name"] = result.drone_name
                 # Global Position
-                tel_dict["global_position"]["latitude"] = result.global_position.latitude
-                tel_dict["global_position"]["longitude"] = result.global_position.longitude
-                tel_dict["global_position"]["altitude"] = result.global_position.altitude
-                tel_dict["global_position"]["relative_altitude"] = result.relative_position.up
+                tel_dict["global_position"]["latitude"] = (
+                    result.global_position.latitude
+                )
+                tel_dict["global_position"]["longitude"] = (
+                    result.global_position.longitude
+                )
+                tel_dict["global_position"]["altitude"] = (
+                    result.global_position.altitude
+                )
+                tel_dict["global_position"]["relative_altitude"] = (
+                    result.relative_position.up
+                )
                 tel_dict["global_position"]["heading"] = result.global_position.heading
                 # Velocity Body
                 tel_dict["velocity_body"]["forward"] = result.velocity_body.forward_vel
@@ -96,7 +114,9 @@ class DataStub(Stub):
 
     async def update_current_task(self, current_task):
         logger.info("Updating current task")
-        req = data_protocol.Request(task=data_protocol.UpdateCurrentTask(task_name=current_task))
+        req = data_protocol.Request(
+            task=data_protocol.UpdateCurrentTask(task_name=current_task)
+        )
         rep = await self.send_and_wait(req)
         logger.info(f"Got response {rep}")
         if rep is None:

--- a/vehicle/mission/system_call_stubs/data_stub.py
+++ b/vehicle/mission/system_call_stubs/data_stub.py
@@ -90,3 +90,10 @@ class DataStub(Stub):
         else:
             logger.error("Failed to get telemetry")    
             return None
+
+    async def send_mission_status(self, current_task):
+        tel = data_protocol.TelemetryRequest()
+        tel.current_task = current_task
+        rep = await self.send_and_wait(tel)
+        if rep is None:
+            logger.error("Failed to send mission status")

--- a/vehicle/mission/system_call_stubs/data_stub.py
+++ b/vehicle/mission/system_call_stubs/data_stub.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 import logging
-from system_call_stubs.stub import Stub
+
 import dataplane_pb2 as data_protocol
+
+from system_call_stubs.stub import Stub
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/mission/system_call_stubs/report_stub.py
+++ b/vehicle/mission/system_call_stubs/report_stub.py
@@ -1,4 +1,3 @@
-import ast
 import json
 import logging
 from system_call_stubs.stub import Stub

--- a/vehicle/mission/system_call_stubs/report_stub.py
+++ b/vehicle/mission/system_call_stubs/report_stub.py
@@ -8,12 +8,12 @@ from system_call_stubs.stub import Stub
 
 logger = logging.getLogger(__name__)
 
-class ReportStub(Stub):
 
+class ReportStub(Stub):
     def __init__(self, user_path):
-        self.waypoint_path = user_path + '/waypoint.json'
+        self.waypoint_path = user_path + "/waypoint.json"
         logger.info(f"ReportStub: waypoint_path: {self.waypoint_path=}")
-        super().__init__(b'usr', 'hub.network.controlplane.mission_to_hub_2', 'report')
+        super().__init__(b"usr", "hub.network.controlplane.mission_to_hub_2", "report")
 
     def parse_control_response(self, response_parts):
         self.parse_response(response_parts, control_protocol.Request)
@@ -21,44 +21,41 @@ class ReportStub(Stub):
     async def run(self):
         await self.receiver_loop(self.parse_control_response)
 
-    ''' Mission methods '''
+    """ Mission methods """
+
     async def send_notification(self, msg):
         logger.info(f"Sending notification: {msg=}")
         report = control_protocol.Response()
-        if (msg == 'start'):
+        if msg == "start":
             report.resp = common_protocol.ResponseStatus.OK
-        elif (msg == 'finish'):
+        elif msg == "finish":
             report.resp = common_protocol.ResponseStatus.COMPLETED
-        
+
         update = await self.send_and_wait(report)
-        
+
         if update is None:
             logger.error("Failed to send notification: No response received")
             return None
-        
-        update_res = {
-            'status': None,
-            'patrol_areas': [],
-            'altitude': None
-        }
+
+        update_res = {"status": None, "patrol_areas": [], "altitude": None}
         if update.msn.patrol_area.status == common_protocol.PatrolStatus.CONTINUE:
-            update_res['status'] = "running"
-            update_res['altitude'] = update.msn.patrol_area.altitude
+            update_res["status"] = "running"
+            update_res["altitude"] = update.msn.patrol_area.altitude
             for patrol_area in update.msn.patrol_area.areas:
-                update_res['patrol_areas'].append(patrol_area)
-        else :
-            update_res['status'] = "finished"
+                update_res["patrol_areas"].append(patrol_area)
+        else:
+            update_res["status"] = "finished"
 
         return update_res
-    
+
     async def get_waypoints(self, area_path):
         try:
             logger.info(f"get_waypoints: {self.waypoint_path=}")
-            with open(self.waypoint_path, 'r') as f:
+            with open(self.waypoint_path, "r") as f:
                 waypoints = f.read()
 
             waypoints_map = json.loads(waypoints)
-            keys = area_path.split('.')
+            keys = area_path.split(".")
             coords = waypoints_map
             for key in keys:
                 coords = coords.get(key)
@@ -66,7 +63,7 @@ class ReportStub(Stub):
                     logger.warning(f"Key '{key}' not found in waypoints map.")
                     return None
 
-            formatted_coords = [{'lng': lng, 'lat': lat} for lng, lat in coords]
+            formatted_coords = [{"lng": lng, "lat": lat} for lng, lat in coords]
             return formatted_coords
 
         except Exception as e:

--- a/vehicle/mission/system_call_stubs/report_stub.py
+++ b/vehicle/mission/system_call_stubs/report_stub.py
@@ -51,7 +51,7 @@ class ReportStub(Stub):
     async def get_waypoints(self, area_path):
         try:
             logger.info(f"get_waypoints: {self.waypoint_path=}")
-            with open(self.waypoint_path, "r") as f:
+            with open(self.waypoint_path) as f:
                 waypoints = f.read()
 
             waypoints_map = json.loads(waypoints)

--- a/vehicle/mission/system_call_stubs/report_stub.py
+++ b/vehicle/mission/system_call_stubs/report_stub.py
@@ -1,8 +1,10 @@
 import json
 import logging
-from system_call_stubs.stub import Stub
-import controlplane_pb2 as control_protocol
+
 import common_pb2 as common_protocol
+import controlplane_pb2 as control_protocol
+
+from system_call_stubs.stub import Stub
 
 logger = logging.getLogger(__name__)
 

--- a/vehicle/mission/system_call_stubs/stub.py
+++ b/vehicle/mission/system_call_stubs/stub.py
@@ -75,5 +75,5 @@ class Stub:
             await stub_response.wait()
             reply =  stub_response.get_result()
             return reply
-        except Exception as e:
+        except Exception:
             return None

--- a/vehicle/mission/system_call_stubs/stub.py
+++ b/vehicle/mission/system_call_stubs/stub.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
+
 import zmq
-from util.utils import setup_socket, SocketOperation
+from util.utils import SocketOperation, setup_socket
+
 logger = logging.getLogger(__name__)
 
 

--- a/vehicle/mission/system_call_stubs/stub.py
+++ b/vehicle/mission/system_call_stubs/stub.py
@@ -71,11 +71,11 @@ class Stub:
             await asyncio.sleep(0)
 
     async def send_and_wait(self, request):
-        try: 
+        try:
             stub_response = StubResponse()
             self.sender(request, stub_response)
             await stub_response.wait()
-            reply =  stub_response.get_result()
+            reply = stub_response.get_result()
             return reply
         except Exception:
             return None

--- a/vehicle/util/timer.py
+++ b/vehicle/util/timer.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 class TimerError(Exception):
@@ -11,11 +10,11 @@ class TimerError(Exception):
 @dataclass
 class Timer:
     logger: logging.Logger
-    name: Optional[str] = None
+    name: str | None = None
     text: str = "{} took {:0.4f} seconds"
-    max_frequency: Optional[int] = None
-    _start_time: Optional[float] = field(default=None, init=False, repr=False)
-    _last_log_time: Optional[int] = None
+    max_frequency: int | None = None
+    _start_time: float | None = field(default=None, init=False, repr=False)
+    _last_log_time: int | None = None
 
     def __enter__(self):
         self.start()

--- a/vehicle/util/timer.py
+++ b/vehicle/util/timer.py
@@ -7,6 +7,7 @@ from typing import Optional
 class TimerError(Exception):
     """A custom exception used to report errors in use of Timer class"""
 
+
 @dataclass
 class Timer:
     logger: logging.Logger

--- a/vehicle/util/timer.py
+++ b/vehicle/util/timer.py
@@ -1,7 +1,8 @@
+import logging
 import time
 from dataclasses import dataclass, field
 from typing import Optional
-import logging
+
 
 class TimerError(Exception):
     """A custom exception used to report errors in use of Timer class"""

--- a/vehicle/util/utils.py
+++ b/vehicle/util/utils.py
@@ -1,6 +1,7 @@
-from enum import Enum
 import logging
 import os
+from enum import Enum
+
 import yaml
 import zmq
 import zmq.asyncio

--- a/vehicle/util/utils.py
+++ b/vehicle/util/utils.py
@@ -104,7 +104,7 @@ def import_config():
     Import configuration file from environment variable.
     """
     config_path = os.environ.get("CONFIG_PATH")
-    with open(config_path, "r") as file:
+    with open(config_path) as file:
         config = yaml.safe_load(file)
         return config
 

--- a/vehicle/util/utils.py
+++ b/vehicle/util/utils.py
@@ -8,25 +8,27 @@ import zmq.asyncio
 
 logger = logging.getLogger(__name__)
 
+
 class SocketOperation(Enum):
     BIND = 1
     CONNECT = 2
 
+
 def setup_socket(socket, socket_op, access_token=None, port_num=None, host_addr="*"):
-    '''
+    """
     Socket setup helper function. Sets up a socket and returns it to the caller,
     either using a provided port number and host address, or using a access token.
-    '''
+    """
     if access_token:
-        indices = access_token.split('.')
+        indices = access_token.split(".")
         # Automatically get the associated endpoint
-        host = query_config(f'{indices[0]}.{indices[1]}.{indices[2]}.endpoint')
+        host = query_config(f"{indices[0]}.{indices[1]}.{indices[2]}.endpoint")
         port = query_config(access_token)
         if not isinstance(port, int):
             raise ValueError("Access token did not yield expected type int")
-        addr = f'tcp://{host}:{port}'
+        addr = f"tcp://{host}:{port}"
     elif isinstance(port_num, int):
-        addr = f'tcp://{host_addr}:{port_num}'
+        addr = f"tcp://{host_addr}:{port_num}"
     else:
         raise ValueError("Expected port number to be an int or a provided access token")
 
@@ -39,12 +41,14 @@ def setup_socket(socket, socket_op, access_token=None, port_num=None, host_addr=
     else:
         raise ValueError("Invalid socket operation")
 
-async def lazy_pirate_request(socket, payload, ctx, server_endpoint, retries=3,
-                              timeout=2500):
-    '''
+
+async def lazy_pirate_request(
+    socket, payload, ctx, server_endpoint, retries=3, timeout=2500
+):
+    """
     Executes a lazy pirate request for client-side reliability. This is discussed
     in the ZeroMQ docs. Visit https://zguide.zeromq.org/docs/chapter4/ to learn more.
-    '''
+    """
     if retries <= 0:
         raise ValueError(f"Retries must be positive; {retries=}")
     # Send payload
@@ -76,48 +80,57 @@ async def lazy_pirate_request(socket, payload, ctx, server_endpoint, retries=3,
         logger.info(f"Resending payload to {server_endpoint=}...")
         socket.send(payload)
 
+
 def query_config(access_token):
-    '''
+    """
     Allows for accessing the config using a plaintext access token.
     An access token indexes a specific socket name in the vehicle config.yaml.
     This must be formatted in a Pythonic module import format. For example, for
     the driver_to_hub telemetry socket under dataplane and hub, it would be
     requested using the id: hub.dataplane.driver_to_hub.telemetry.
-    '''
+    """
     config = import_config()
-    indices = access_token.split('.')
+    indices = access_token.split(".")
     result = config
     for i in indices:
         if i not in result.keys():
             raise ValueError(f"Malformed access token: {access_token}")
-        result = result[i] # Access the corresponding field
+        result = result[i]  # Access the corresponding field
     return result
 
+
 def import_config():
-    '''
+    """
     Import configuration file from environment variable.
-    '''
-    config_path = os.environ.get('CONFIG_PATH')
-    with open(config_path, 'r') as file:
+    """
+    config_path = os.environ.get("CONFIG_PATH")
+    with open(config_path, "r") as file:
         config = yaml.safe_load(file)
         return config
 
+
 def setup_logging(logger, access_token=None):
-    logging_format = "%(asctime)s [%(levelname)s] (%(filename)s:%(lineno)d) - %(message)s"
+    logging_format = (
+        "%(asctime)s [%(levelname)s] (%(filename)s:%(lineno)d) - %(message)s"
+    )
     logging_config = None
     if access_token is not None:
         logging_config = query_config(access_token)
 
     if logging_config is not None:
-        logging.basicConfig(level=logging_config['log_level'], format=logging_format, force=True)
+        logging.basicConfig(
+            level=logging_config["log_level"], format=logging_format, force=True
+        )
     else:
-        log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
-        logging.basicConfig(level=getattr(logging, log_level, logging.INFO), format=logging_format)
+        log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+        logging.basicConfig(
+            level=getattr(logging, log_level, logging.INFO), format=logging_format
+        )
         return
 
-    log_file = logging_config['log_file']
+    log_file = logging_config["log_file"]
     if log_file:
-        file_handler = logging.FileHandler(log_file, mode='w')
+        file_handler = logging.FileHandler(log_file, mode="w")
         file_handler.setFormatter(logging.Formatter(logging_format))
-        file_handler.setLevel(logging_config['log_level'])
+        file_handler.setLevel(logging_config["log_level"])
         logging.getLogger().addHandler(file_handler)


### PR DESCRIPTION
Fixes are all over the place and who knows how much got broken as a result.

I read through the diff a few times now and it mostly looks reasonable, but I guess people should at least look it over.
Alternatively, it may be useful to cherry pick some of the specific commits that actually fix obvious errors and leave some of the reordering of imports to the formatter.

Once a ruff format is done and merged, it is probably fine to re-enable E501 (long lines) and E701 (multiple statements on one line) because most of those should get fixed by reformatting.

Over time more checks can be enabled, like CPY (if all files have the copyright blurbs) and PTH (use Path instead of os.path), enabling all checks (after formatting) flags 4388 issues, but that includes a lot of nice to have but not critical things like missing docstrings and type annotations.